### PR TITLE
Ajout d'un squelette plugin Bakkesmod et bot Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # AuusaConnect
+
+Ce dépôt contient un exemple minimal permettant de relier Rocket League (via un plugin Bakkesmod) à un bot Discord pour un système de matchmaking.
+
+## Contenu
+
+- `plugin/` : squelette du plugin Bakkesmod. Il envoie les scores de fin de match au bot Discord.
+- `bot/` : petit serveur Node.js utilisant Discord.js et Express pour recevoir les données du plugin et les publier dans un salon.
+
+Chaque dossier possède un `README.md` détaillant la mise en place.

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,21 @@
+# Bot Discord Matchmaking
+
+Ce dossier contient un bot Discord minimal en Node.js.
+Il expose un endpoint HTTP pour recevoir les données du plugin et les affiche dans un salon Discord.
+
+## Prérequis
+
+- Node.js >= 18
+- Un token de bot Discord
+
+## Installation
+
+```bash
+npm install
+```
+
+## Lancement
+
+```bash
+DISCORD_TOKEN=VOTRE_TOKEN node index.js
+```

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,35 @@
+import { Client, GatewayIntentBits } from 'discord.js';
+import express from 'express';
+import bodyParser from 'body-parser';
+
+const app = express();
+app.use(bodyParser.json());
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
+let channelId = '';
+
+app.post('/match', (req, res) => {
+  const { scoreBlue, scoreOrange } = req.body;
+  if (channelId && client.channels.cache.has(channelId)) {
+    const channel = client.channels.cache.get(channelId);
+    channel.send(`Match terminé: Bleu ${scoreBlue} - Orange ${scoreOrange}`);
+  }
+  res.sendStatus(200);
+});
+
+client.once('ready', () => {
+  console.log('Bot prêt');
+});
+
+client.on('interactionCreate', async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+  if (interaction.commandName === 'setchannel') {
+    channelId = interaction.channelId;
+    await interaction.reply('Canal enregistré pour les résultats de match.');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`API en écoute sur le port ${PORT}`));
+
+client.login(process.env.DISCORD_TOKEN);

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "matchmaking-bot",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "discord.js": "^14.0.0",
+    "express": "^4.18.0",
+    "body-parser": "^1.20.0"
+  }
+}

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -1,0 +1,51 @@
+#include "bakkesmod/plugin/bakkesmodplugin.h"
+#include <cpr/cpr.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+class MatchmakingPlugin : public BakkesMod::Plugin::BakkesModPlugin
+{
+public:
+    void onLoad() override;
+    void onUnload() override;
+
+private:
+    void HookEvents();
+    void OnGameEnd();
+};
+
+void MatchmakingPlugin::onLoad()
+{
+    HookEvents();
+}
+
+void MatchmakingPlugin::onUnload()
+{
+}
+
+void MatchmakingPlugin::HookEvents()
+{
+    gameWrapper->HookEventPost("Function TAGame.GameEvent_Soccar_TA.EventMatchEnded", std::bind(&MatchmakingPlugin::OnGameEnd, this));
+}
+
+void MatchmakingPlugin::OnGameEnd()
+{
+    ServerWrapper sw = gameWrapper->GetCurrentGameState();
+    if (!sw)
+        return;
+
+    int scoreBlue = sw.GetGameEventAsServer().GetTeams().Get(0).GetScore();
+    int scoreOrange = sw.GetGameEventAsServer().GetTeams().Get(1).GetScore();
+
+    json payload = {
+        {"scoreBlue", scoreBlue},
+        {"scoreOrange", scoreOrange}
+    };
+
+    cpr::Response r = cpr::Post(cpr::Url{"http://localhost:3000/match"},
+                                cpr::Body{payload.dump()},
+                                cpr::Header{{"Content-Type", "application/json"}});
+}
+
+BAKKESMOD_PLUGIN(MatchmakingPlugin, "Matchmaking Plugin", "1.0", 0)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,14 @@
+# Plugin Matchmaking Rocket League
+
+Ce dossier contient un squelette de plugin Bakkesmod.
+
+## Compilation
+
+1. Installer [Bakkesmod SDK](https://github.com/bakkesmodorg/BakkesModSDK) et suivez les instructions pour configurer Visual Studio.
+2. Copier les fichiers de ce dossier dans un projet de plugin Bakkesmod.
+3. Ajouter la dépendance à la bibliothèque [cpr](https://github.com/libcpr/cpr) pour effectuer des requêtes HTTP.
+4. Compiler en Release et placer le `.dll` généré dans le dossier `bakkesmod/plugins`.
+
+## Fonctionnement
+
+Le plugin récupère des informations simples en fin de match et les envoie au bot Discord via une requête HTTP POST.


### PR DESCRIPTION
## Résumé
- création du dossier `plugin` contenant un exemple de plugin Bakkesmod
- ajout d'un serveur Node.js dans `bot` pour recevoir les scores et les publier sur Discord
- mise à jour de la documentation pour expliquer la mise en place

## Test
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_687f07a3d59c832c8d44fdfaf211ba03