### PR TITLE
Fix plugin score retrieval

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -35,8 +35,8 @@ void MatchmakingPlugin::OnGameEnd()
     if (!sw)
         return;
 
-    int scoreBlue = sw.GetGameEventAsServer().GetTeams().Get(0).GetScore();
-    int scoreOrange = sw.GetGameEventAsServer().GetTeams().Get(1).GetScore();
+    int scoreBlue = sw.GetTeams().Get(0).GetScore();
+    int scoreOrange = sw.GetTeams().Get(1).GetScore();
 
     json payload = {
         {"scoreBlue", scoreBlue},


### PR DESCRIPTION
## Summary
- correct method to get team scores from `ServerWrapper`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688447b422e4832c982f6b51fd5f5fde