### PR TITLE
Register Discord slash command

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -19,3 +19,7 @@ npm install
 ```bash
 DISCORD_TOKEN=VOTRE_TOKEN node index.js
 ```
+
+Au premier lancement, le bot enregistre automatiquement la commande slash
+`/setchannel`. Utilisez-la dans le salon souhaité pour que les scores y soient
+publiés.

--- a/bot/index.js
+++ b/bot/index.js
@@ -17,8 +17,18 @@ app.post('/match', (req, res) => {
   res.sendStatus(200);
 });
 
-client.once('ready', () => {
+client.once('ready', async () => {
   console.log('Bot prêt');
+
+  // Enregistre la commande slash /setchannel si elle n'existe pas
+  try {
+    await client.application.commands.create({
+      name: 'setchannel',
+      description: 'Choisir le salon où publier les scores'
+    });
+  } catch (err) {
+    console.error('Erreur lors de la création des commandes :', err);
+  }
 });
 
 client.on('interactionCreate', async interaction => {


### PR DESCRIPTION
## Summary
- register `/setchannel` command on startup
- document slash command registration in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68846ac51a74832c8b8670fc60c9f0dd