### PR TITLE
Send detailed match info to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ce dépôt contient un exemple minimal permettant de relier Rocket League (via u
 
 ## Contenu
 
-- `plugin/` : squelette du plugin Bakkesmod. Il envoie les scores de fin de match au bot Discord.
+- `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match ainsi que le détail des joueurs (buteurs, MVP, arrêts...).
 - `bot/` : petit serveur Node.js utilisant Discord.js et Express pour recevoir les données du plugin et les publier dans un salon.
 
 Chaque dossier possède un `README.md` détaillant la mise en place.

--- a/bot/README.md
+++ b/bot/README.md
@@ -23,3 +23,7 @@ DISCORD_TOKEN=VOTRE_TOKEN node index.js
 Au premier lancement, le bot enregistre automatiquement la commande slash
 `/setchannel`. Utilisez-la dans le salon souhaité pour que les scores y soient
 publiés.
+
+Le bot reçoit désormais des informations détaillées sur la partie (buteurs, MVP,
+scores individuels et arrêts) et les présente sous forme de message formaté dans
+le salon configuré.

--- a/bot/index.js
+++ b/bot/index.js
@@ -9,10 +9,19 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBit
 let channelId = '';
 
 app.post('/match', (req, res) => {
-  const { scoreBlue, scoreOrange } = req.body;
+  const { scoreBlue, scoreOrange, scorers = [], mvp = '', players = [] } = req.body;
   if (channelId && client.channels.cache.has(channelId)) {
     const channel = client.channels.cache.get(channelId);
-    channel.send(`Match terminé: Bleu ${scoreBlue} - Orange ${scoreOrange}`);
+    const lines = [`Match terminé: Bleu ${scoreBlue} - Orange ${scoreOrange}`];
+    if (mvp) lines.push(`MVP : ${mvp}`);
+    if (scorers.length) lines.push(`Buteurs : ${scorers.join(', ')}`);
+    if (players.length) {
+      lines.push('Scores joueurs :');
+      for (const p of players) {
+        lines.push(`${p.name} - ${p.goals} buts, ${p.saves} arrêts, ${p.score} pts`);
+      }
+    }
+    channel.send(lines.join('\n'));
   }
   res.sendStatus(200);
 });

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -1,6 +1,8 @@
 #include "bakkesmod/plugin/bakkesmodplugin.h"
 #include <cpr/cpr.h>
 #include <nlohmann/json.hpp>
+#include <vector>
+#include <string>
 
 using json = nlohmann::json;
 
@@ -38,9 +40,43 @@ void MatchmakingPlugin::OnGameEnd()
     int scoreBlue = sw.GetTeams().Get(0).GetScore();
     int scoreOrange = sw.GetTeams().Get(1).GetScore();
 
+    ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
+    json players = json::array();
+    json scorers = json::array();
+    std::string mvp = "";
+    int bestScore = -1;
+
+    for (int i = 0; i < pris.Count(); ++i)
+    {
+        PriWrapper pri = pris.Get(i);
+        if (!pri)
+            continue;
+
+        json p = {
+            {"name", pri.GetPlayerName().ToString()},
+            {"team", pri.GetTeamNum2()},
+            {"goals", pri.GetGoals()},
+            {"saves", pri.GetSaves()},
+            {"score", pri.GetMatchScore()}
+        };
+        players.push_back(p);
+
+        if (pri.GetGoals() > 0)
+            scorers.push_back(pri.GetPlayerName().ToString());
+
+        if (pri.GetMatchScore() > bestScore)
+        {
+            bestScore = pri.GetMatchScore();
+            mvp = pri.GetPlayerName().ToString();
+        }
+    }
+
     json payload = {
         {"scoreBlue", scoreBlue},
-        {"scoreOrange", scoreOrange}
+        {"scoreOrange", scoreOrange},
+        {"scorers", scorers},
+        {"mvp", mvp},
+        {"players", players}
     };
 
     cpr::Response r = cpr::Post(cpr::Url{"http://localhost:3000/match"},

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -11,4 +11,10 @@ Ce dossier contient un squelette de plugin Bakkesmod.
 
 ## Fonctionnement
 
-Le plugin récupère des informations simples en fin de match et les envoie au bot Discord via une requête HTTP POST.
+Le plugin récupère les informations de fin de match et les envoie au bot Discord via une requête HTTP POST.
+Il transmet notamment :
+
+- le score global des équipes ;
+- la liste des joueurs ayant marqué ;
+- le nom du MVP ;
+- pour chaque joueur, son nombre de buts, d'arrêts et son score.


### PR DESCRIPTION
## Summary
- enrich plugin to collect scorers, MVP, individual scores and saves
- update Discord bot to display these details
- document the new behaviour in READMEs

## Testing
- `node --check bot/index.js`


------
https://chatgpt.com/codex/tasks/task_e_688533849548832c98f6c598d107ad55