### PR TITLE
Ajout statistiques rotation et boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ce dépôt contient un exemple minimal permettant de relier Rocket League (via u
 
 ## Contenu
 
-- `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match ainsi que le détail des joueurs (buteurs, MVP, arrêts...).
+ - `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match ainsi que des statistiques détaillées (buteurs, MVP, utilisation du boost...).
 - `bot/` : petit serveur Node.js utilisant Discord.js et Express pour recevoir les données du plugin et les publier dans un salon.
 
 Chaque dossier possède un `README.md` détaillant la mise en place.

--- a/bot/README.md
+++ b/bot/README.md
@@ -24,6 +24,4 @@ Au premier lancement, le bot enregistre automatiquement la commande slash
 `/setchannel`. Utilisez-la dans le salon souhaité pour que les scores y soient
 publiés.
 
-Le bot reçoit désormais des informations détaillées sur la partie (buteurs, MVP,
-scores individuels et arrêts) et les présente sous forme de message formaté dans
-le salon configuré.
+Le bot reçoit désormais des informations détaillées sur la partie (buteurs, MVP, scores individuels, utilisation du boost) et les présente sous forme de message formaté dans le salon configuré. Pour chaque joueur sont indiquées la fréquence de prise de boost, la proportion de petits pads ramassés et le nombre de boosts gaspillés.

--- a/bot/index.js
+++ b/bot/index.js
@@ -19,6 +19,11 @@ app.post('/match', (req, res) => {
       lines.push('Scores joueurs :');
       for (const p of players) {
         lines.push(`${p.name} - ${p.goals} buts, ${p.saves} arrêts, ${p.score} pts`);
+        if (p.boostPickups !== undefined) {
+          lines.push(`\tRotations : ${(p.rotationQuality * 100).toFixed(0)}% petits pads`);
+          lines.push(`\tFréquence boost : ${p.boostFrequency.toFixed(2)}/s`);
+          lines.push(`\tBoosts gaspillés : ${p.wastedBoostPickups}`);
+        }
       }
     }
     channel.send(lines.join('\n'));

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -6,6 +6,15 @@
 
 using json = nlohmann::json;
 
+struct PlayerStats
+{
+    int boostPickups = 0;
+    int wastedBoosts = 0;
+    int smallPads = 0;
+    int bigPads = 0;
+    float lastBoost = -1.f;
+};
+
 class MatchmakingPlugin : public BakkesMod::Plugin::BakkesModPlugin
 {
 public:
@@ -14,7 +23,11 @@ public:
 
 private:
     void HookEvents();
+    void OnMatchStart(ServerWrapper server);
+    void TickBoost();
     void OnGameEnd();
+
+    std::map<std::string, PlayerStats> stats;
 };
 
 void MatchmakingPlugin::onLoad()
@@ -28,7 +41,56 @@ void MatchmakingPlugin::onUnload()
 
 void MatchmakingPlugin::HookEvents()
 {
-    gameWrapper->HookEventPost("Function TAGame.GameEvent_Soccar_TA.EventMatchEnded", std::bind(&MatchmakingPlugin::OnGameEnd, this));
+    gameWrapper->HookEventWithCallerPost<ServerWrapper>(
+        "Function TAGame.GameEvent_Soccar_TA.EventMatchStarted",
+        std::bind(&MatchmakingPlugin::OnMatchStart, this, std::placeholders::_1));
+    gameWrapper->HookEventPost(
+        "Function TAGame.GameEvent_Soccar_TA.EventMatchEnded",
+        std::bind(&MatchmakingPlugin::OnGameEnd, this));
+}
+
+void MatchmakingPlugin::OnMatchStart(ServerWrapper server)
+{
+    stats.clear();
+    TickBoost();
+}
+
+void MatchmakingPlugin::TickBoost()
+{
+    ServerWrapper sw = gameWrapper->GetCurrentGameState();
+    if (sw)
+    {
+        ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
+        for (int i = 0; i < pris.Count(); ++i)
+        {
+            PriWrapper pri = pris.Get(i);
+            if (!pri)
+                continue;
+
+            std::string name = pri.GetPlayerName().ToString();
+            CarWrapper car = pri.GetCar();
+            if (!car)
+                continue;
+            BoostWrapper boost = car.GetBoostComponent();
+            if (!boost)
+                continue;
+
+            PlayerStats &ps = stats[name];
+            float current = boost.GetCurrentBoostAmount();
+            if (ps.lastBoost >= 0 && current - ps.lastBoost > 1.f)
+            {
+                ps.boostPickups++;
+                if (ps.lastBoost >= boost.GetMaxBoostAmount() * 0.8f)
+                    ps.wastedBoosts++;
+                if (current - ps.lastBoost > 90.f)
+                    ps.bigPads++;
+                else
+                    ps.smallPads++;
+            }
+            ps.lastBoost = current;
+        }
+    }
+    gameWrapper->SetTimeout(std::bind(&MatchmakingPlugin::TickBoost, this), 0.1f);
 }
 
 void MatchmakingPlugin::OnGameEnd()
@@ -52,12 +114,19 @@ void MatchmakingPlugin::OnGameEnd()
         if (!pri)
             continue;
 
+        std::string pname = pri.GetPlayerName().ToString();
+        PlayerStats ps = stats[pname];
+        float totalTime = sw.GetGameEventAsServer().GetTotalGameTimePlayed();
         json p = {
-            {"name", pri.GetPlayerName().ToString()},
+            {"name", pname},
             {"team", pri.GetTeamNum2()},
             {"goals", pri.GetMatchGoals()},
             {"saves", pri.GetMatchSaves()},
-            {"score", pri.GetMatchScore()}
+            {"score", pri.GetMatchScore()},
+            {"boostPickups", ps.boostPickups},
+            {"wastedBoostPickups", ps.wastedBoosts},
+            {"boostFrequency", totalTime > 0 ? ps.boostPickups / totalTime : 0},
+            {"rotationQuality", ps.boostPickups > 0 ? (float)ps.smallPads / ps.boostPickups : 0}
         };
         players.push_back(p);
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -18,3 +18,7 @@ Il transmet notamment :
 - la liste des joueurs ayant marqué ;
 - le nom du MVP ;
 - pour chaque joueur, son nombre de buts, d'arrêts et son score.
+- ainsi que des statistiques sur l'utilisation du boost :
+  - fréquence de prise de boost ;
+  - nombre de boosts gaspillés (pris alors que la jauge était presque pleine) ;
+  - un indicateur simple de la rotation basé sur la proportion de petits pads pris.


### PR DESCRIPTION
## Résumé
- collecte en continu la consommation de boost des joueurs
- envoie de nouvelles statistiques (fréquence, gaspillages, petits/grands pads)
- affichage détaillé côté bot
- documentation mise à jour

## Tests
- `npm test --silent` (aucun test défini)


------
https://chatgpt.com/codex/tasks/task_e_688540fddb50832c84fa884b659be06e