### PR TITLE
Ajout statistiques avancées et noms d'équipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ce dépôt contient un exemple minimal permettant de relier Rocket League (via u
 
 ## Contenu
 
-- `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match ainsi que le détail des joueurs (buteurs, MVP, arrêts...).
+- `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match ainsi que le détail des joueurs (buteurs, passes décisives, tirs cadrés, MVP, arrêts...).
 - `bot/` : petit serveur Node.js utilisant Discord.js et Express pour recevoir les données du plugin et les publier dans un salon.
 
 Chaque dossier possède un `README.md` détaillant la mise en place.

--- a/bot/README.md
+++ b/bot/README.md
@@ -24,6 +24,4 @@ Au premier lancement, le bot enregistre automatiquement la commande slash
 `/setchannel`. Utilisez-la dans le salon souhaité pour que les scores y soient
 publiés.
 
-Le bot reçoit désormais des informations détaillées sur la partie (buteurs, MVP,
-scores individuels et arrêts) et les présente sous forme de message formaté dans
-le salon configuré.
+Le bot reçoit désormais des informations détaillées sur la partie (buteurs, passes décisives, tirs cadrés, MVP, scores individuels, arrêts et vrais noms d'équipe) et les présente sous forme de message formaté dans le salon configuré.

--- a/bot/index.js
+++ b/bot/index.js
@@ -9,16 +9,26 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBit
 let channelId = '';
 
 app.post('/match', (req, res) => {
-  const { scoreBlue, scoreOrange, scorers = [], mvp = '', players = [] } = req.body;
+  const {
+    scoreBlue,
+    scoreOrange,
+    teamBlue = 'Bleu',
+    teamOrange = 'Orange',
+    scorers = [],
+    mvp = '',
+    players = []
+  } = req.body;
   if (channelId && client.channels.cache.has(channelId)) {
     const channel = client.channels.cache.get(channelId);
-    const lines = [`Match terminé: Bleu ${scoreBlue} - Orange ${scoreOrange}`];
+    const lines = [`Match terminé: ${teamBlue} ${scoreBlue} - ${teamOrange} ${scoreOrange}`];
     if (mvp) lines.push(`MVP : ${mvp}`);
     if (scorers.length) lines.push(`Buteurs : ${scorers.join(', ')}`);
     if (players.length) {
       lines.push('Scores joueurs :');
       for (const p of players) {
-        lines.push(`${p.name} - ${p.goals} buts, ${p.saves} arrêts, ${p.score} pts`);
+        lines.push(
+          `${p.name} - ${p.goals} buts, ${p.assists} passes, ${p.shots} tirs, ${p.saves} arrêts, ${p.score} pts`
+        );
       }
     }
     channel.send(lines.join('\n'));

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -37,8 +37,14 @@ void MatchmakingPlugin::OnGameEnd()
     if (!sw)
         return;
 
-    int scoreBlue = sw.GetTeams().Get(0).GetScore();
-    int scoreOrange = sw.GetTeams().Get(1).GetScore();
+    TeamWrapper blueTeam = sw.GetTeams().Get(0);
+    TeamWrapper orangeTeam = sw.GetTeams().Get(1);
+
+    int scoreBlue = blueTeam.GetScore();
+    int scoreOrange = orangeTeam.GetScore();
+
+    std::string blueName = blueTeam.GetTeamName().ToString();
+    std::string orangeName = orangeTeam.GetTeamName().ToString();
 
     ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
     json players = json::array();
@@ -56,6 +62,8 @@ void MatchmakingPlugin::OnGameEnd()
             {"name", pri.GetPlayerName().ToString()},
             {"team", pri.GetTeamNum2()},
             {"goals", pri.GetMatchGoals()},
+            {"assists", pri.GetMatchAssists()},
+            {"shots", pri.GetMatchShots()},
             {"saves", pri.GetMatchSaves()},
             {"score", pri.GetMatchScore()}
         };
@@ -74,6 +82,8 @@ void MatchmakingPlugin::OnGameEnd()
     json payload = {
         {"scoreBlue", scoreBlue},
         {"scoreOrange", scoreOrange},
+        {"teamBlue", blueName},
+        {"teamOrange", orangeName},
         {"scorers", scorers},
         {"mvp", mvp},
         {"players", players}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -17,4 +17,5 @@ Il transmet notamment :
 - le score global des équipes ;
 - la liste des joueurs ayant marqué ;
 - le nom du MVP ;
-- pour chaque joueur, son nombre de buts, d'arrêts et son score.
+- pour chaque joueur, son nombre de buts, de passes décisives, de tirs cadrés, d'arrêts et son score.
+- les noms exacts des équipes telles qu'affichées en jeu.


### PR DESCRIPTION
## Summary
- ajoute les passes décisives et les tirs cadrés dans les données envoyées
- inclut désormais les noms exacts des équipes in‑game
- affiche ces informations côté bot Discord
- met à jour les documentations correspondantes

## Testing
- `npm install`
- `npm test` *(échoue : Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6885408430c8832caa520929cb3348c2