### PR TITLE
Fix total game time retrieval

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -122,7 +122,8 @@ void MatchmakingPlugin::OnGameEnd()
 
         std::string pname = pri.GetPlayerName().ToString();
         PlayerStats ps = stats[pname];
-        float totalTime = sw.GetGameEventAsServer().GetTotalGameTimePlayed();
+        // Utilise directement le temps total de jeu expose par ServerWrapper
+        float totalTime = sw.GetTotalGameTimePlayed();
         json p = {
             {"name", pname},
             {"team", pri.GetTeamNum2()},


### PR DESCRIPTION
## Summary
- use `GetTotalGameTimePlayed` from `ServerWrapper`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6885440dc480832caaed59ece63a39a6