### PR TITLE
Ajout des statistiques offensives

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -33,6 +33,9 @@ app.post('/match', (req, res) => {
         lines.push(
           `\u2514 Boosts pris: ${p.boostPickups} (gaspillés: ${p.wastedBoostPickups}), fréquence ${p.boostFrequency.toFixed(2)}/s, ${rotation}`
         );
+        lines.push(
+          `\u2514 Temps en attaque: ${p.attackTime.toFixed(1)}s, pressings: ${p.pressings}, démolitions offensives: ${p.offensiveDemos}`
+        );
       }
     }
     channel.send(lines.join('\n'));


### PR DESCRIPTION
## Summary
- enrichir la structure `PlayerStats` pour inclure les statistiques offensives
- ajouter l'écoute d'événements (but, touche de balle, démolition)
- suivre le temps passé en zone offensive
- envoyer ces nouvelles stats au bot Discord
- afficher les nouvelles données dans le bot

## Testing
- `node -c bot/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68859487a244832ca46d74a9f01f315a