### PR TITLE
Add man of the match in Discord recap

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -30,6 +30,27 @@ app.post('/match', (req, res) => {
       return Math.round(avg * 100);
     };
 
+    const motm = () => {
+      let best = null;
+      let bestVal = -Infinity;
+      for (const p of players) {
+        const val =
+          (p.score || 0) +
+          (p.goals || 0) * 100 +
+          (p.assists || 0) * 50 +
+          (p.saves || 0) * 50 +
+          (p.shots || 0) * 10 +
+          ((p.rotationQuality || 0) * 100);
+        if (val > bestVal) {
+          bestVal = val;
+          best = p;
+        }
+      }
+      return best;
+    };
+
+    const motmPlayer = motm();
+
     const embed = new EmbedBuilder()
       .setTitle(`🏁 Match terminé : ${teamBlue} ${scoreBlue} – ${scoreOrange} ${teamOrange}`)
       .addFields(
@@ -40,8 +61,15 @@ app.post('/match', (req, res) => {
         },
         {
           name: `🟠 ${teamOrange}`,
-          value: `👤 : ${orangePlayers.map(p => p.name).join(', ')}\n🎯 Tirs : ${sum(orangePlayers, 'shots')}\t⚽ Buts : ${sum(orangePlayers, 'goals')}\t🛡️ Arrêts : ${sum(orangePlayers, 'saves')}\n🔄 Score de rotation : ${rotationScore(orangePlayers)}/100`,
-          inline: true
+      value: `👤 : ${orangePlayers.map(p => p.name).join(', ')}\n🎯 Tirs : ${sum(orangePlayers, 'shots')}\t⚽ Buts : ${sum(orangePlayers, 'goals')}\t🛡️ Arrêts : ${sum(orangePlayers, 'saves')}\n🔄 Score de rotation : ${rotationScore(orangePlayers)}/100`,
+      inline: true
+        },
+        {
+          name: '👑 Homme du match :',
+          value: motmPlayer
+            ? `**${motmPlayer.name}** (Buts: ${motmPlayer.goals}, Passes: ${motmPlayer.assists}, Arrêts: ${motmPlayer.saves}, Score: ${motmPlayer.score}, Rotation: ${Math.round((motmPlayer.rotationQuality || 0) * 100)}/100)`
+            : 'Aucun',
+          inline: false
         }
       )
       .setColor('#00b0f4')


### PR DESCRIPTION
## Summary
- compute rotation score and man of the match values in the bot
- extend the embed with a new field to show the best player

## Testing
- `node --check bot/index.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68864c6464dc832cad2b87c248084661