### PR TITLE
Fix missing error stats

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -292,7 +292,16 @@ void MatchmakingPlugin::OnGameEnd()
             {"defensiveDemos", ps.defensiveDemos},
             {"defenseTime", ps.defenseTime},
             {"clutchSaves", ps.clutchSaves},
-            {"blocks", ps.blocks}
+            {"blocks", ps.blocks},
+            {"offensiveDemos", ps.offensiveDemos},
+            {"missedOpenGoals", ps.missedOpenGoals},
+            {"doubleCommits", ps.doubleCommits},
+            {"uselessTouches", ps.uselessTouches},
+            {"ballTouches", ps.ballTouches},
+            {"highPressings", ps.highPressings},
+            {"aerialTouches", ps.aerialTouches},
+            {"usefulPasses", ps.usefulPasses},
+            {"cleanClears", ps.cleanClears}
         };
         players.push_back(p);
 


### PR DESCRIPTION
## Summary
- enrichir la payload du plugin en ajoutant toutes les stats d'erreurs et d'activité

## Testing
- `npm test` *(échoue : script absent)*

------
https://chatgpt.com/codex/tasks/task_e_68884d2a78e8832c8f831cbf6c56036d