### PR TITLE
Fix Vision & Support stats

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -292,7 +292,15 @@ void MatchmakingPlugin::OnGameEnd()
             {"defensiveDemos", ps.defensiveDemos},
             {"defenseTime", ps.defenseTime},
             {"clutchSaves", ps.clutchSaves},
-            {"blocks", ps.blocks}
+            {"blocks", ps.blocks},
+            {"usefulPasses", ps.usefulPasses},
+            {"cleanClears", ps.cleanClears},
+            {"missedOpenGoals", ps.missedOpenGoals},
+            {"doubleCommits", ps.doubleCommits},
+            {"uselessTouches", ps.uselessTouches},
+            {"aerialTouches", ps.aerialTouches},
+            {"highPressings", ps.highPressings},
+            {"ballTouches", ps.ballTouches}
         };
         players.push_back(p);
 


### PR DESCRIPTION
## Summary
- send additional player stats from the plugin to the Discord bot

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68884ce17bf8832c986cbed7e8a94e00