### PR TITLE
Fix demo stats detection

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -487,20 +487,6 @@ void MatchmakingPlugin::OnCarDemolish(CarWrapper car, void* /*params*/, std::str
     if (!pri)
         return;
 
-    Vector pos = car.GetLocation();
-    int team = pri.GetTeamNum2();
-    if ((team == 0 && pos.Y < 0) || (team == 1 && pos.Y > 0))
-    {
-        PlayerStats &ps = stats[pri.GetPlayerName().ToString()];
-        ps.defensiveDemos++;
-        if (debugEnabled)
-        {
-            float time = gameWrapper->GetCurrentGameState().GetSecondsElapsed();
-            cvarManager->log("[DEBUG] Demo defensive par " + pri.GetPlayerName().ToString() + " t:" + std::to_string(time));
-        }
-    }
-
-    // Identifie le démolisseur via le champ Attacker du CarWrapper
     PriWrapper attacker = car.GetAttackerPRI();
     if (attacker)
     {
@@ -509,7 +495,20 @@ void MatchmakingPlugin::OnCarDemolish(CarWrapper car, void* /*params*/, std::str
         {
             Vector aloc = ac.GetLocation();
             int aTeam = attacker.GetTeamNum2();
-            if ((aTeam == 0 && aloc.X > 0) || (aTeam == 1 && aloc.X < 0))
+
+            // Demo effectuee dans sa propre moitie -> demolition defensive
+            if ((aTeam == 0 && aloc.Y < 0) || (aTeam == 1 && aloc.Y > 0))
+            {
+                stats[attacker.GetPlayerName().ToString()].defensiveDemos++;
+                if (debugEnabled)
+                {
+                    float time = gameWrapper->GetCurrentGameState().GetSecondsElapsed();
+                    cvarManager->log("[DEBUG] Demo defensive par " + attacker.GetPlayerName().ToString() + " t:" + std::to_string(time));
+                }
+            }
+
+            // Demo effectuee dans la moitie adverse -> demolition offensive
+            if ((aTeam == 0 && aloc.Y > 0) || (aTeam == 1 && aloc.Y < 0))
             {
                 stats[attacker.GetPlayerName().ToString()].offensiveDemos++;
                 if (debugEnabled)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -37,7 +37,8 @@ Les métriques ci-dessous permettent d'analyser plus finement l'impact défensif
 | **Arrêts** | `GetSaves()` ou interception d'un tir cadré bloqué | En direct pour incrémentation, résumée en fin de match | Tir cadré stoppé dans la moitié défensive | entier |
 | **Dégagements** | Position de la balle frappée depuis sa moitié vers l'adversaire | En direct | Distance parcourue supérieure à un seuil et balle éloignée de la zone dangereuse | entier |
 | **Challenges gagnés** | Événement de contact (`CarWrapper` et `BallWrapper`) dans sa moitié | En direct | Duel remporté (50/50) en zone défensive | entier |
-| **Démolitions défensives** | `OnDemolition()` filtré par position du joueur | En direct | L'adversaire est détruit près de son propre but | entier |
+| **Démolitions défensives** | `OnDemolition()` filtré par position du joueur défenseur | En direct | L'adversaire est démoli dans la moitié défensive du joueur | entier |
+| **Démolitions offensives** | `OnDemolition()` filtré par position du joueur attaquant | En direct | L'adversaire est démoli dans sa propre moitié de terrain | entier |
 | **Temps en défense** | Suivi continu de `CarWrapper.GetLocation()` < ligne médiane | Continu puis somme à la fin | Joueur présent dans sa moitié de terrain | secondes ou pourcentage du temps de jeu |
 | **Sauvetages critiques** | Vérification du nombre de coéquipiers derrière le ballon lors d'un arrêt | En direct | Dernier défenseur entre l'attaquant et le but et tir cadré | entier |
 | **Blocks** | Contact balle adverse + redirection de trajectoire | En direct | Blocage d'un tir ou d'une passe dangereuse | entier |


### PR DESCRIPTION
## Summary
- record defensive demos for the attacker instead of the victim
- detect offensive demos using Y position
- document offensive demos in plugin README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688862b4f4f4832cb1b18802bd90896b