### PR TITLE
Fix boost pickup tracking for rotation stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ce dépôt contient un exemple minimal permettant de relier Rocket League (via u
 
 ## Contenu
 
-- `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match, les statistiques individuelles (buteurs, passes décisives, tirs cadrés, arrêts, MVP, etc.) ainsi que des informations de rotation (pickups de boost, fréquence et gaspillage). Le plugin fournit également des statistiques défensives détaillées pour mesurer l'impact de chaque joueur.
+- `plugin/` : squelette du plugin Bakkesmod. Il envoie au bot Discord les scores de fin de match, les statistiques individuelles (buteurs, passes décisives, tirs cadrés, arrêts, MVP, etc.) ainsi qu'un indicateur complet de qualité de rotation calculé à partir de la position 1er/2ᵉ/3ᵉ homme tout au long du match. Le plugin fournit également des statistiques défensives détaillées pour mesurer l'impact de chaque joueur.
 - `bot/` : petit serveur Node.js utilisant Discord.js et Express pour recevoir les données du plugin et les publier dans un salon.
 
 Chaque dossier possède un `README.md` détaillant la mise en place.

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <map>
 #include <cmath>
+#include <algorithm>
+#include <utility>
 
 using json = nlohmann::json;
 
@@ -40,6 +42,16 @@ struct PlayerStats
     int aerialTouches = 0;
     int highPressings = 0;
     int ballTouches = 0;
+
+    // Suivi des roles de rotation
+    float roleTime[3] = {0.f, 0.f, 0.f};
+    int cuts = 0;
+    float aggressiveTime = 0.f;
+    float passiveTime = 0.f;
+    float ballchaseTime = 0.f;
+    int lastRole = -1;
+    float firstStreak = 0.f;
+    float thirdStreak = 0.f;
 
     // Etats internes
     bool inAttack = false;
@@ -166,6 +178,7 @@ void MatchmakingPlugin::TickStats()
 
         ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
         Vector ballLoc = ball.GetLocation();
+        std::vector<std::pair<PriWrapper, float>> teamPlayers[2];
         for (int i = 0; i < pris.Count(); ++i)
         {
             PriWrapper pri = pris.Get(i);
@@ -181,18 +194,9 @@ void MatchmakingPlugin::TickStats()
             PlayerStats &ps = stats[name];
             if (boost)
             {
-                float current = boost.GetCurrentBoostAmount();
-                if (ps.lastBoost >= 0 && current - ps.lastBoost > 1.f)
-                {
-                    ps.boostPickups++;
-                    if (ps.lastBoost >= boost.GetMaxBoostAmount() * 0.8f)
-                        ps.wastedBoosts++;
-                    if (current - ps.lastBoost > 90.f)
-                        ps.bigPads++;
-                    else
-                        ps.smallPads++;
-                }
-                ps.lastBoost = current;
+                // Mise a jour simple de la valeur actuelle pour permettre un suivi correct
+                // dans l'evenement OnBoostCollected sans compter deux fois les pickups.
+                ps.lastBoost = boost.GetCurrentBoostAmount();
             }
 
             Vector pos = car.GetLocation();
@@ -225,6 +229,60 @@ void MatchmakingPlugin::TickStats()
                 }
                 if (lastDef)
                     ps.clutchSaves++;
+            }
+
+            float dist = (pos - ballLoc).magnitude();
+            teamPlayers[team].push_back({pri, dist});
+        }
+
+        for (int t = 0; t < 2; ++t)
+        {
+            auto &vec = teamPlayers[t];
+            std::sort(vec.begin(), vec.end(), [](const auto &a, const auto &b){ return a.second < b.second; });
+            for (size_t j = 0; j < vec.size(); ++j)
+            {
+                PriWrapper pri = vec[j].first;
+                if (!pri)
+                    continue;
+                std::string name = pri.GetPlayerName().ToString();
+                PlayerStats &ps = stats[name];
+
+                int role = static_cast<int>(j) + 1;
+                if (role <= 3)
+                    ps.roleTime[role - 1] += dt;
+
+                ps.timeSinceAttack += dt;
+
+                if (ps.lastRole != -1 && role < ps.lastRole - 1)
+                    ps.cuts++;
+
+                if (role == 1)
+                    ps.firstStreak += dt;
+                else
+                {
+                    if (ps.firstStreak > 5.f)
+                        ps.aggressiveTime += ps.firstStreak;
+                    ps.firstStreak = 0.f;
+                }
+
+                if (role == 3)
+                    ps.thirdStreak += dt;
+                else
+                {
+                    if (ps.thirdStreak > 5.f)
+                        ps.passiveTime += ps.thirdStreak;
+                    ps.thirdStreak = 0.f;
+                }
+
+                if (ps.inAttack)
+                {
+                    if (ps.timeSinceAttack > 3.f && role != 3)
+                        ps.ballchaseTime += dt;
+                    if (role == 3 && ps.timeSinceAttack > 1.f)
+                        ps.inAttack = false;
+                }
+
+                ps.lastRole = role;
             }
         }
     }
@@ -275,6 +333,14 @@ void MatchmakingPlugin::OnGameEnd()
         PlayerStats ps = stats[pname];
         // Utilise directement le temps total de jeu expose par ServerWrapper
         float totalTime = sw.GetTotalGameTimePlayed();
+        float rTotal = ps.roleTime[0] + ps.roleTime[1] + ps.roleTime[2];
+        float ideal = rTotal / 3.f;
+        float diff = rTotal > 0.f ? (fabs(ps.roleTime[0] - ideal) + fabs(ps.roleTime[1] - ideal) + fabs(ps.roleTime[2] - ideal)) / rTotal : 0.f;
+        float scoreRot = 100.f - diff * 40.f - ps.cuts * 5.f
+                         - ps.aggressiveTime * 10.f - ps.passiveTime * 10.f
+                         - ps.ballchaseTime * 15.f;
+        scoreRot = std::clamp(scoreRot, 0.f, 100.f);
+
         json p = {
             {"name", pname},
             {"team", pri.GetTeamNum2()},
@@ -286,7 +352,11 @@ void MatchmakingPlugin::OnGameEnd()
             {"boostPickups", ps.boostPickups},
             {"wastedBoostPickups", ps.wastedBoosts},
             {"boostFrequency", totalTime > 0 ? ps.boostPickups / totalTime : 0},
-            {"rotationQuality", ps.boostPickups > 0 ? (float)ps.smallPads / ps.boostPickups : 0},
+            {"rotationQuality", scoreRot},
+            {"role1Frequency", rTotal > 0.f ? ps.roleTime[0] / rTotal : 0.f},
+            {"role2Frequency", rTotal > 0.f ? ps.roleTime[1] / rTotal : 0.f},
+            {"role3Frequency", rTotal > 0.f ? ps.roleTime[2] / rTotal : 0.f},
+            {"cuts", ps.cuts},
             {"clearances", ps.clearances},
             {"defensiveChallenges", ps.challengesWon},
             {"defensiveDemos", ps.defensiveDemos},
@@ -534,7 +604,21 @@ void MatchmakingPlugin::OnBoostCollected(CarWrapper car, void* /*params*/, std::
 
     std::string name = pri.GetPlayerName().ToString();
     PlayerStats &ps = stats[name];
+
+    float current = boost.GetCurrentBoostAmount();
+    float gained = ps.lastBoost >= 0.f ? current - ps.lastBoost : 0.f;
+
     ps.boostPickups++;
+    if (ps.lastBoost >= 0.f && gained > 0.f)
+    {
+        if (ps.lastBoost >= boost.GetMaxBoostAmount() * 0.8f)
+            ps.wastedBoosts++;
+        if (gained > 90.f)
+            ps.bigPads++;
+        else
+            ps.smallPads++;
+    }
+    ps.lastBoost = current;
 
     if (debugEnabled)
     {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -25,7 +25,7 @@ Il transmet notamment :
 - le nom du MVP ;
 - pour chaque joueur, son nombre de buts, de passes décisives, de tirs cadrés, d'arrêts et son score.
 - les noms exacts des équipes telles qu'affichées en jeu.
-- pour chaque joueur, des statistiques de boost et un indicateur de qualité de rotation (nombre de ramassages, gaspillage, fréquence d'utilisation et part de petits pads).
+- pour chaque joueur, des statistiques de boost et un indicateur de qualité de rotation évalué à partir de sa position dans la rotation (1er/2ᵉ/3ᵉ homme) tout au long du match.
 - des statistiques défensives détaillées (arrêts, dégagements, challenges gagnés, démolitions, temps passé en défense, sauvetages critiques et blocks).
 
 ## Statistiques défensives


### PR DESCRIPTION
## Summary
- fix double counting of boost pickups in TickStats
- compute wasted boosts and pad types in `OnBoostCollected`
- add advanced rotation quality score based on player positions
- report role frequencies and cuts in match stats
- update documentation for new rotation evaluation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888621c444c832cb4eb68a9cc56237d