### PR TITLE
Fix setup command definition

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -33,8 +33,8 @@ Au premier lancement, le bot enregistre automatiquement la commande slash
   vérification est posté et ses informations sont mémorisées dans
   `verify.json`.
 
-La commande `/setup` installe la vérification dans le salon actuel. Elle crée
-les rôles **Membre** et **Non vérifié** si besoin, poste le message de
-vérification et enregistre ces informations dans `verify.json`.
+Pour installer la vérification, utilisez la sous‑commande `/setup verification`.
+Cette action crée les rôles **Membre** et **Non vérifié** si besoin, poste le
+message de vérification puis enregistre ces informations dans `verify.json`.
 
 Le bot reçoit désormais des informations détaillées sur la partie (buteurs, passes décisives, tirs cadrés, MVP, scores individuels, arrêts et vrais noms d'équipe) et les présente sous forme de message formaté dans le salon configuré.

--- a/bot/index.js
+++ b/bot/index.js
@@ -235,10 +235,6 @@ client.once('ready', async () => {
         }
       ]
     });
-    await client.application.commands.create({
-      name: 'setup',
-      description: 'Installer la vérification dans ce salon'
-    });
   } catch (err) {
     console.error('Erreur lors de la création des commandes :', err);
   }


### PR DESCRIPTION
## Summary
- remove duplicate `/setup` command definition
- clarify README about using `/setup verification`

## Testing
- `npm test` *(fails: Missing script)*
- `node --eval "require('./index.js');"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688a4bb43344832c9505ad73d1972671