### PR TITLE
Fix setup command definition

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -33,8 +33,7 @@ Au premier lancement, le bot enregistre automatiquement la commande slash
   vérification est posté et ses informations sont mémorisées dans
   `verify.json`.
 
-La commande `/setup` installe la vérification dans le salon actuel. Elle crée
-les rôles **Membre** et **Non vérifié** si besoin, poste le message de
-vérification et enregistre ces informations dans `verify.json`.
+Pour installer la vérification, utilisez la sous‑commande `/setup verification`.
+Cette action crée les rôles **Membre** et **Non vérifié** si besoin, puis cherche s'il existe déjà un message avec une réaction dans ce salon. Si c'est le cas, le message le plus récent est utilisé comme support de vérification et la réaction ✅ y est ajoutée. Sinon, le bot poste un nouveau message de vérification. Les informations sont ensuite enregistrées dans `verify.json`.
 
 Le bot reçoit désormais des informations détaillées sur la partie (buteurs, passes décisives, tirs cadrés, MVP, scores individuels, arrêts et vrais noms d'équipe) et les présente sous forme de message formaté dans le salon configuré.

--- a/bot/index.js
+++ b/bot/index.js
@@ -235,10 +235,6 @@ client.once('ready', async () => {
         }
       ]
     });
-    await client.application.commands.create({
-      name: 'setup',
-      description: 'Installer la vérification dans ce salon'
-    });
   } catch (err) {
     console.error('Erreur lors de la création des commandes :', err);
   }

--- a/bot/verification.js
+++ b/bot/verification.js
@@ -77,8 +77,23 @@ export async function runVerificationSetup(interaction) {
     unverified = await guild.roles.create({ name: unverifiedName, reason: 'Role non vérifié' }).catch(() => null);
   }
 
-  const msg = await interaction.channel.send('Cliquez sur ✅ pour accéder au serveur.');
-  await msg.react('✅');
+  // Cherche s'il existe déjà un message avec une réaction dans ce salon
+  let msg = null;
+  try {
+    const messages = await interaction.channel.messages.fetch({ limit: 50 });
+    msg = messages.find(m => m.reactions.cache.size > 0) || null;
+  } catch {
+    msg = null;
+  }
+
+  // Sinon crée un nouveau message pour la vérification
+  if (!msg) {
+    msg = await interaction.channel.send('Cliquez sur ✅ pour accéder au serveur.');
+  }
+
+  if (!msg.reactions.cache.has('✅')) {
+    await msg.react('✅');
+  }
 
   fs.writeFileSync(VERIFY_FILE, JSON.stringify({ channelId: interaction.channel.id, messageId: msg.id }));
   await interaction.reply({ content: 'Système de vérification installé.', ephemeral: true });


### PR DESCRIPTION
## Summary
- remove duplicate `/setup` command definition
- clarify README about using `/setup verification`
- reuse latest message with a reaction as the verification prompt

## Testing
- `npm test` *(fails: Missing script)*
- `node --eval "require('./index.js');"` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688a4bb43344832c9505ad73d1972671