### PR TITLE
Add missing stats to plugin payload

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -386,6 +386,7 @@ void MatchmakingPlugin::OnGameEnd()
             {"cuts", ps.cuts},
             {"clearances", ps.clearances},
             {"defensiveChallenges", ps.challengesWon},
+            {"offensiveDemos", ps.offensiveDemos},
             {"defensiveDemos", ps.defensiveDemos},
             {"defenseTime", ps.defenseTime},
             {"clutchSaves", ps.clutchSaves},
@@ -393,6 +394,8 @@ void MatchmakingPlugin::OnGameEnd()
             {"ballTouches", ps.ballTouches},
             {"highPressings", ps.highPressings},
             {"aerialTouches", ps.aerialTouches},
+            {"usefulPasses", ps.usefulPasses},
+            {"cleanClears", ps.cleanClears},
             {"missedOpenGoals", ps.missedOpenGoals},
             {"doubleCommits", ps.doubleCommits}
         };


### PR DESCRIPTION
## Summary
- send offensiveDemos, usefulPasses and cleanClears in match data

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688afb505824832c9305e5cf06dd6869