### PR TITLE
Ajout d'un rôle pour /team invite

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -50,3 +50,7 @@ Vous pouvez préciser un rôle existant avec l'option `role` pour qu'il soit att
 Une fois la vérification active, tout nouveau membre se voit attribuer automatiquement le rôle **Non vérifié**. Il devra cliquer sur la réaction pour recevoir le rôle de membre classique.
 
 Le bot reçoit désormais des informations détaillées sur la partie (buteurs, passes décisives, tirs cadrés, MVP, scores individuels, arrêts et vrais noms d'équipe) et les présente sous forme de message formaté dans le salon configuré.
+
+### Gestion des équipes
+
+La commande `/team invite` accepte désormais une option `role` pour définir le rôle du joueur invité : `member` (par défaut), `coach` ou `manager`.


### PR DESCRIPTION
## Résumé
- ajout de l'option `role` à la sous-commande `/team invite`
- prise en compte du rôle lors de la validation de l'invitation
- mise à jour de la documentation

## Tests
- `node --check bot/team.js`
- `node --check bot/index.js`

------
https://chatgpt.com/codex/tasks/task_e_688b4c1e1a00832c9c29121fbb4b0d22