### PR TITLE
Mise à jour de l'embed de création d'équipe

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -72,7 +72,13 @@ export function setupTeam(client) {
         if (exists.length) return interaction.reply({ content: 'Ce nom est déjà pris.', ephemeral: true });
         const team = await sbRequest('POST', 'teams', { body: { name, description, captain_id: interaction.user.id, elo: 1000 } });
         await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: team[0].id } });
-        await interaction.reply(`Équipe **${name}** créée !`);
+        const embed = new EmbedBuilder()
+          .setTitle('✅ Équipe créée avec succès !')
+          .setDescription(`🆕 Nom : **${name}**  \n👑 Capitaine : <@${interaction.user.id}>  \n👥 Membres : *(0/6)*\n\nℹ️ Tu peux maintenant inviter des joueurs avec :  \n\`/team invite @joueur\``)
+          .setColor('#a47864')
+          .setFooter({ iconURL: 'https://i.imgur.com/9FLBUiC.png' })
+          .setTimestamp();
+        await interaction.reply({ embeds: [embed] });
       } else if (sub === 'invite') {
         const user = interaction.options.getUser('joueur');
         const team = await findTeamByUser(interaction.user.id);


### PR DESCRIPTION
## Résumé
- améliore l'affichage de confirmation lors de la création d'une équipe
- ajout d'un embed dynamique avec nom, capitaine et aide pour inviter des joueurs

## Test
- `npm test` *(échoue : script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_688b4ef92740832cb714a72a3e237bb9