### PR TITLE
Implémente /enregistrement

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 import { setupMatchmaking } from './matchmaking.js';
 import { setupVerification, runVerificationSetup } from './verification.js';
 import { setupTeam } from './team.js';
+import { setupRegistration } from './registration.js';
 import express from 'express';
 import bodyParser from 'body-parser';
 
@@ -46,6 +47,7 @@ const matchData = new Map();
 setupMatchmaking(client);
 setupVerification(client);
 setupTeam(client);
+setupRegistration(client);
 
 const calculateMotm = players => {
   let best = null;

--- a/bot/registration.js
+++ b/bot/registration.js
@@ -1,0 +1,99 @@
+import { ApplicationCommandOptionType, EmbedBuilder } from 'discord.js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_KEY;
+
+async function sbRequest(method, table, { query = '', body } = {}) {
+  const url = `${SUPABASE_URL}/rest/v1/${table}${query ? `?${query}` : ''}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      apikey: SUPABASE_KEY,
+      Authorization: `Bearer ${SUPABASE_KEY}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation'
+    },
+    body: body ? JSON.stringify(body) : undefined
+  });
+  if (!res.ok) {
+    let msg;
+    try { msg = (await res.json()).message; } catch { msg = res.statusText; }
+    throw new Error(msg);
+  }
+  return res.json();
+}
+
+export function setupRegistration(client) {
+  client.once('ready', async () => {
+    try {
+      await client.application.commands.create({
+        name: 'enregistrement',
+        description: 'Lier votre pseudo Rocket League',
+        options: [
+          {
+            name: 'pseudo',
+            description: 'Pseudo Rocket League',
+            type: ApplicationCommandOptionType.String,
+            required: true
+          }
+        ]
+      });
+    } catch (err) {
+      console.error('Création commande /enregistrement échouée', err);
+    }
+  });
+
+  client.on('interactionCreate', async interaction => {
+    if (!interaction.isChatInputCommand() || interaction.commandName !== 'enregistrement') return;
+    const rlName = interaction.options.getString('pseudo').trim();
+    const guild = interaction.guild;
+    if (!guild) return interaction.reply({ content: 'Commande uniquement sur un serveur.', ephemeral: true });
+
+    try {
+      const existing = await sbRequest('GET', 'users', { query: `rl_name=eq.${encodeURIComponent(rlName)}` });
+      if (existing.length && existing[0].discord_id !== interaction.user.id) {
+        return interaction.reply({ content: 'Ce pseudo Rocket League est déjà utilisé.', ephemeral: true });
+      }
+
+      let userRows = await sbRequest('GET', 'users', { query: `discord_id=eq.${interaction.user.id}` });
+      if (userRows.length) {
+        const body = { rl_name: rlName, registered_at: new Date().toISOString() };
+        if (userRows[0].mmr === null) body.mmr = 1200;
+        await sbRequest('PATCH', `users?discord_id=eq.${interaction.user.id}`, { body });
+        userRows = await sbRequest('GET', 'users', { query: `discord_id=eq.${interaction.user.id}` });
+      } else {
+        const body = { discord_id: interaction.user.id, rl_name: rlName, mmr: 1200, registered_at: new Date().toISOString() };
+        userRows = await sbRequest('POST', 'users', { body });
+      }
+      const user = userRows[0];
+
+      try {
+        await interaction.member.setNickname(`[${user.mmr}] ${rlName}`);
+      } catch (err) {
+        console.error('Erreur changement pseudo', err);
+      }
+
+      const roleName = process.env.REGISTERED_ROLE || '🟢 Joueur enregistré';
+      const role = guild.roles.cache.find(r => r.name === roleName);
+      if (role) await interaction.member.roles.add(role).catch(() => {});
+
+      const embed = new EmbedBuilder()
+        .setTitle('✅ Enregistrement terminé !')
+        .setDescription(
+          `🎮 Pseudo Rocket League : **${rlName}**\n` +
+          `🧠 MMR initial : **${user.mmr}**\n` +
+          `📎 Ton pseudo a été mis à jour → \`[${user.mmr}] ${rlName}\`\n` +
+          '🟢 Tu peux maintenant rejoindre les vocaux de matchmaking.'
+        )
+        .setColor('#a47864')
+        .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
+        .setTimestamp();
+
+      await interaction.reply({ embeds: [embed] });
+    } catch (err) {
+      console.error(err);
+      await interaction.reply({ content: `Erreur : ${err.message}`, ephemeral: true });
+    }
+  });
+}
+


### PR DESCRIPTION
## Résumé
- ajoute `registration.js` avec la commande `/enregistrement`
- enregistre la nouvelle commande dans `index.js`

## Tests
- `node --check index.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b62b95c30832cb23af56f1b0c9eb4