### PR TITLE
Add Supabase DB schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,49 @@ Ce dépôt contient un exemple minimal permettant de relier Rocket League (via u
 - `bot/` : petit serveur Node.js utilisant Discord.js et Express pour recevoir les données du plugin et les publier dans un salon.
 
 Chaque dossier possède un `README.md` détaillant la mise en place.
+
+## Base de données Supabase
+
+Les tables suivantes doivent être créées dans votre projet Supabase :
+
+### `teams`
+
+| Colonne       | Type      | Clé étrangère            |
+|--------------|-----------|--------------------------|
+| `id`         | `uuid`    | clé primaire             |
+| `name`       | `text`    |                          |
+| `description`| `text`    |                          |
+| `captain_id` | `uuid`    | référence `auth.users.id`|
+| `coach_id`   | `uuid`    | référence `auth.users.id`|
+| `manager_id` | `uuid`    | référence `auth.users.id`|
+| `elo`        | `integer` |                          |
+| `logo`       | `text`    |                          |
+
+### `team_members`
+
+| Colonne  | Type   | Clé étrangère           |
+|----------|--------|-------------------------|
+| `id`     | `uuid` | clé primaire            |
+| `team_id`| `uuid` | référence `teams.id`    |
+| `user_id`| `uuid` | référence `auth.users.id`|
+
+### `team_invitations`
+
+| Colonne  | Type   | Clé étrangère           |
+|----------|--------|-------------------------|
+| `id`     | `uuid` | clé primaire            |
+| `team_id`| `uuid` | référence `teams.id`    |
+| `user_id`| `uuid` | référence `auth.users.id`|
+| `status` | `text` |                         |
+| `role`   | `text` |                         |
+
+### `match_history`
+
+| Colonne  | Type       | Clé étrangère       |
+|----------|------------|--------------------|
+| `id`     | `uuid`     | clé primaire       |
+| `team_a` | `uuid`     | référence `teams.id`|
+| `team_b` | `uuid`     | référence `teams.id`|
+| `score`  | `text`     |                    |
+| `date`   | `timestamp`|                    |
+| `winner` | `uuid`     | référence `teams.id`|


### PR DESCRIPTION
## Summary
- document required Supabase tables and columns in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b68ed305c832cad802e6819dc9756