### PR TITLE
Update docs for invitation role

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -54,3 +54,4 @@ Le bot reçoit désormais des informations détaillées sur la partie (buteurs, 
 ### Gestion des équipes
 
 La commande `/team invite` accepte désormais une option `role` pour définir le rôle du joueur invité : `member` (par défaut), `coach` ou `manager`.
+La table `team_invitations` doit donc comporter une colonne `role` de type `text` enregistrant ce choix.


### PR DESCRIPTION
## Summary
- clarify that the `team_invitations` table now includes a `role` column

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b68d9d0ac832c9a64820ac5803a70