### PR TITLE
Create team resources automatically

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -122,6 +122,7 @@ export function setupTeam(client) {
         if (exists.length) return interaction.reply({ content: 'Ce nom est déjà pris.', ephemeral: true });
         const team = await sbRequest('POST', 'teams', { body: { name, description, captain_id: interaction.user.id, elo: 1000 } });
         await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: team[0].id } });
+        await createTeamResources(interaction, name);
         const embed = new EmbedBuilder()
           .setTitle('✅ Équipe créée avec succès !')
           .setDescription(`🆕 Nom : **${name}**  \n👑 Capitaine : <@${interaction.user.id}>  \n👥 Membres : *(0/6)*\n\nℹ️ Tu peux maintenant inviter des joueurs avec :  \n\`/team invite @joueur\``)


### PR DESCRIPTION
## Summary
- create team channels and role right after storing the captain in DB

## Testing
- `npm install`
- `node --check team.js`

------
https://chatgpt.com/codex/tasks/task_e_688b68ec082c832c90a2a90f259e05b6