### PR TITLE
Fix team footer text

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -126,7 +126,7 @@ export function setupTeam(client) {
           .setTitle('✅ Équipe créée avec succès !')
           .setDescription(`🆕 Nom : **${name}**  \n👑 Capitaine : <@${interaction.user.id}>  \n👥 Membres : *(0/6)*\n\nℹ️ Tu peux maintenant inviter des joueurs avec :  \n\`/team invite @joueur\``)
           .setColor('#a47864')
-          .setFooter({ iconURL: 'https://i.imgur.com/9FLBUiC.png' })
+          .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
           .setTimestamp();
         await interaction.reply({ embeds: [embed] });
       } else if (sub === 'invite') {


### PR DESCRIPTION
## Summary
- complémente le footer de la création d'équipe avec le texte standard
- vérifie que tous les footers comportent bien la propriété `text`

## Testing
- `npm test` *(échoue : script absent)*

------
https://chatgpt.com/codex/tasks/task_e_688b68d5b4ac832cb938595a08dbb9f1