### PR TITLE
Fix ephemeral replies with flags

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -7,7 +7,8 @@ import {
   ButtonStyle,
   StringSelectMenuBuilder,
   ApplicationCommandOptionType,
-  Partials
+  Partials,
+  MessageFlags
 } from 'discord.js';
 import 'dotenv/config';
 import fs from 'fs';
@@ -273,7 +274,7 @@ client.on('interactionCreate', async interaction => {
   if (interaction.isButton() && interaction.customId === 'details_joueur') {
     const players = matchData.get(interaction.message.id);
     if (!players) {
-      await interaction.reply({ content: 'Données indisponibles.', ephemeral: true });
+      await interaction.reply({ content: 'Données indisponibles.', flags: MessageFlags.Ephemeral });
       return;
     }
     const options = players.map(p => ({
@@ -288,7 +289,7 @@ client.on('interactionCreate', async interaction => {
     await interaction.reply({
       content: 'Sélectionnez un joueur :',
       components: [new ActionRowBuilder().addComponents(select)],
-      ephemeral: true
+      flags: MessageFlags.Ephemeral
     });
     return;
   }
@@ -296,13 +297,13 @@ client.on('interactionCreate', async interaction => {
   if (interaction.isButton() && interaction.customId === 'team_analysis_button') {
     const players = matchData.get(interaction.message.id);
     if (!players) {
-      await interaction.reply({ content: 'Données indisponibles.', ephemeral: true });
+      await interaction.reply({ content: 'Données indisponibles.', flags: MessageFlags.Ephemeral });
       return;
     }
     const username = (interaction.member?.nickname || interaction.user.username).toLowerCase();
     const player = players.find(p => p.name.toLowerCase() === username);
     if (!player) {
-      await interaction.reply({ content: "Impossible de déterminer ton équipe.", ephemeral: true });
+      await interaction.reply({ content: "Impossible de déterminer ton équipe.", flags: MessageFlags.Ephemeral });
       return;
     }
     const teamPlayers = players.filter(p => p.team === player.team);
@@ -317,7 +318,7 @@ client.on('interactionCreate', async interaction => {
       )
       .setColor('#00BFFF')
       .setTimestamp();
-    await interaction.reply({ embeds: [analysisEmbed], ephemeral: true });
+    await interaction.reply({ embeds: [analysisEmbed], flags: MessageFlags.Ephemeral });
     return;
   }
 
@@ -326,12 +327,12 @@ client.on('interactionCreate', async interaction => {
     const players = matchData.get(matchId);
     const selected = interaction.values[0];
     if (!players) {
-      await interaction.reply({ content: 'Données indisponibles.', ephemeral: true });
+      await interaction.reply({ content: 'Données indisponibles.', flags: MessageFlags.Ephemeral });
       return;
     }
     const player = players.find(p => p.name === selected);
     if (!player) {
-      await interaction.reply({ content: 'Aucune donnée pour ce joueur.', ephemeral: true });
+      await interaction.reply({ content: 'Aucune donnée pour ce joueur.', flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -366,7 +367,7 @@ client.on('interactionCreate', async interaction => {
       .setColor('#00b0f4')
       .setTimestamp();
 
-    await interaction.reply({ embeds: [detailEmbed], ephemeral: true });
+    await interaction.reply({ embeds: [detailEmbed], flags: MessageFlags.Ephemeral });
     return;
   }
 
@@ -374,14 +375,14 @@ client.on('interactionCreate', async interaction => {
     const matchId = interaction.customId.replace('select_compare_', '');
     const players = matchData.get(matchId);
     if (!players) {
-      await interaction.reply({ content: 'Données indisponibles.', ephemeral: true });
+      await interaction.reply({ content: 'Données indisponibles.', flags: MessageFlags.Ephemeral });
       return;
     }
     const [nameA, nameB] = interaction.values;
     const pA = players.find(p => p.name === nameA);
     const pB = players.find(p => p.name === nameB);
     if (!pA || !pB) {
-      await interaction.reply({ content: 'Aucune donnée pour ces joueurs.', ephemeral: true });
+      await interaction.reply({ content: 'Aucune donnée pour ces joueurs.', flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -420,7 +421,7 @@ client.on('interactionCreate', async interaction => {
       .setColor('#800080')
       .setTimestamp();
 
-    await interaction.reply({ embeds: [compareEmbed], ephemeral: true });
+    await interaction.reply({ embeds: [compareEmbed], flags: MessageFlags.Ephemeral });
   }
 });
 

--- a/bot/matchmaking.js
+++ b/bot/matchmaking.js
@@ -4,6 +4,7 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  MessageFlags,
 } from 'discord.js';
 
 export function setupMatchmaking(client) {
@@ -79,14 +80,14 @@ export function setupMatchmaking(client) {
 
     collector.on('collect', async i => {
       if (!players.some(p => p.id === i.user.id)) {
-        await i.reply({ content: 'Vous ne participez pas à ce match.', ephemeral: true });
+        await i.reply({ content: 'Vous ne participez pas à ce match.', flags: MessageFlags.Ephemeral });
         return;
       }
       if (i.customId === 'ready_yes') {
         ready.add(i.user.id);
-        await i.reply({ content: 'Validé.', ephemeral: true });
+        await i.reply({ content: 'Validé.', flags: MessageFlags.Ephemeral });
       } else {
-        await i.reply({ content: 'Match annulé.', ephemeral: true });
+        await i.reply({ content: 'Match annulé.', flags: MessageFlags.Ephemeral });
         collector.stop('refused:' + i.user.id);
       }
       if (ready.size === players.length) collector.stop('validated');
@@ -123,7 +124,7 @@ export function setupMatchmaking(client) {
     const msg = await text.send({ content: 'Cliquez sur le bouton pour terminer le match.', components: [new ActionRowBuilder().addComponents(btn)] });
     const coll = msg.createMessageComponentCollector({ time: 2 * 60 * 60 * 1000 });
     coll.on('collect', async i => {
-      await i.reply({ content: 'Nettoyage...', ephemeral: true });
+      await i.reply({ content: 'Nettoyage...', flags: MessageFlags.Ephemeral });
       coll.stop();
       await text.delete().catch(() => {});
       await vocal.delete().catch(() => {});

--- a/bot/registration.js
+++ b/bot/registration.js
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, EmbedBuilder } from 'discord.js';
+import { ApplicationCommandOptionType, EmbedBuilder, MessageFlags } from 'discord.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_KEY;
@@ -47,12 +47,12 @@ export function setupRegistration(client) {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'enregistrement') return;
     const rlName = interaction.options.getString('pseudo').trim();
     const guild = interaction.guild;
-    if (!guild) return interaction.reply({ content: 'Commande uniquement sur un serveur.', ephemeral: true });
+    if (!guild) return interaction.reply({ content: 'Commande uniquement sur un serveur.', flags: MessageFlags.Ephemeral });
 
     try {
       const existing = await sbRequest('GET', 'users', { query: `rl_name=eq.${encodeURIComponent(rlName)}` });
       if (existing.length && existing[0].discord_id !== interaction.user.id) {
-        return interaction.reply({ content: 'Ce pseudo Rocket League est déjà utilisé.', ephemeral: true });
+        return interaction.reply({ content: 'Ce pseudo Rocket League est déjà utilisé.', flags: MessageFlags.Ephemeral });
       }
 
       let userRows = await sbRequest('GET', 'users', { query: `discord_id=eq.${interaction.user.id}` });
@@ -92,7 +92,7 @@ export function setupRegistration(client) {
       await interaction.reply({ embeds: [embed] });
     } catch (err) {
       console.error(err);
-      await interaction.reply({ content: `Erreur : ${err.message}`, ephemeral: true });
+      await interaction.reply({ content: `Erreur : ${err.message}`, flags: MessageFlags.Ephemeral });
     }
   });
 }

--- a/bot/verification.js
+++ b/bot/verification.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { MessageFlags } from 'discord.js';
 
 async function applyRolesFromReactions(message, storedRoleId) {
   const guild = message.guild;
@@ -155,5 +156,5 @@ export async function runVerificationSetup(interaction) {
   await applyRolesFromReactions(msg, verified ? verified.id : null);
 
   fs.writeFileSync(VERIFY_FILE, JSON.stringify({ channelId: interaction.channel.id, messageId: msg.id, roleId: verified ? verified.id : null }));
-  await interaction.reply({ content: 'Système de vérification installé.', ephemeral: true });
+  await interaction.reply({ content: 'Système de vérification installé.', flags: MessageFlags.Ephemeral });
 }


### PR DESCRIPTION
## Summary
- update Discord client imports to use `MessageFlags`
- replace deprecated `ephemeral` option with `flags: MessageFlags.Ephemeral`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bd3fcc240832cb0bd4b7baa35c669