### PR TITLE
Prevent duplicate team membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Les tables suivantes doivent être créées dans votre projet Supabase :
 | `team_id`| `uuid` | référence `teams.id`    |
 | `user_id`| `uuid` | référence `auth.users.id`|
 
+Chaque utilisateur ne peut appartenir qu'à une seule équipe. Une contrainte d'unicité sur `user_id` est donc recommandée pour éviter les doublons dans `team_members`.
+
 ### `team_invitations`
 
 | Colonne  | Type   | Clé étrangère           |

--- a/bot/team.js
+++ b/bot/team.js
@@ -125,6 +125,10 @@ export function setupTeam(client) {
       if (sub === 'create') {
         const name = interaction.options.getString('nom');
         const description = interaction.options.getString('description');
+        const existingTeam = await findTeamByUser(interaction.user.id);
+        if (existingTeam) {
+          return interaction.reply({ content: 'Vous faites déjà partie d\'une équipe.', flags: MessageFlags.Ephemeral });
+        }
         const exists = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(name)}` });
         if (exists.length) return interaction.reply({ content: 'Ce nom est déjà pris.', flags: MessageFlags.Ephemeral });
         const team = await sbRequest('POST', 'teams', { body: { name, description, captain_id: interaction.user.id, elo: 1000 } });
@@ -157,6 +161,10 @@ export function setupTeam(client) {
         } catch {}
         await interaction.reply({ content: `${user} a été invité dans **${team.name}**.`, flags: MessageFlags.Ephemeral });
       } else if (sub === 'join') {
+        const memberOf = await findTeamByUser(interaction.user.id);
+        if (memberOf) {
+          return interaction.reply({ content: 'Vous faites déjà partie d\'une équipe.', flags: MessageFlags.Ephemeral });
+        }
         const name = interaction.options.getString('nom');
         const teamRows = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(name)}` });
         if (!teamRows.length) return interaction.reply({ content: 'Équipe introuvable.', flags: MessageFlags.Ephemeral });


### PR DESCRIPTION
## Summary
- avoid adding a user to multiple teams by checking membership on team creation and join
- note uniqueness of `user_id` in `team_members`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688be3ece530832cb6d6a0f77ed10620