### PR TITLE
Refonte interactive du module TEAM

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -1,8 +1,17 @@
 import {
+  Client,
   ApplicationCommandOptionType,
   EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
   ChannelType,
   PermissionsBitField,
+  ComponentType,
   MessageFlags
 } from 'discord.js';
 import fs from 'fs';
@@ -88,31 +97,73 @@ async function createTeamResources(interaction, name) {
   return role;
 }
 
+async function buildTeamEmbed(team) {
+  const members = await sbRequest('GET', 'team_members', { query: `team_id=eq.${team.id}` });
+  const wins = (await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&winner=eq.${team.id}` })).length;
+  const losses = (await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&winner=neq.${team.id}` })).filter(m => m.winner).length;
+  const lastRows = await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&order=id.desc&limit=1` });
+  let lastField = 'Aucun match enregistré.';
+  if (lastRows.length) {
+    const match = lastRows[0];
+    const opp = await sbRequest('GET', 'teams', { query: `id=eq.${match.team_b}` });
+    const oppName = opp[0]?.name || 'Inconnu';
+    const result = match.winner ? (match.winner === team.id ? 'Victoire' : 'Défaite') : 'Match en attente';
+    lastField = `vs ${oppName} → ${result} ${match.score || ''}`;
+    if (match.date) lastField += ` (${match.date})`;
+  }
+  const embed = new EmbedBuilder()
+    .setTitle(`🔰 ${team.name}`)
+    .addFields(
+      { name: '👑 Capitaine', value: `<@${team.captain_id}>`, inline: true },
+      { name: '👥 Membres', value: `${members.length}/6`, inline: true },
+      { name: '🧠 Élo', value: String(team.elo), inline: true },
+      { name: '🏅 Dernier match', value: lastField, inline: false }
+    )
+    .setColor('#a47864')
+    .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
+    .setTimestamp();
+  if (team.description) embed.setDescription(`> ${team.description}`);
+  embed.setImage(team.logo || 'https://i.imgur.com/HczhXhK.png');
+  return embed;
+}
+
+async function showMainMenu(interaction) {
+  const team = await findTeamByUser(interaction.user.id);
+  if (!team) {
+    const embed = new EmbedBuilder()
+      .setTitle('Aucune équipe trouvée')
+      .setDescription("Tu n'es dans aucune équipe.")
+      .setColor('#a47864');
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId('team_create').setLabel('Créer une équipe').setStyle(ButtonStyle.Success),
+      new ButtonBuilder().setCustomId('team_join').setLabel('Rejoindre une équipe').setStyle(ButtonStyle.Primary)
+    );
+    await interaction.editReply({ embeds: [embed], components: [row] });
+    return;
+  }
+  const embed = await buildTeamEmbed(team);
+  const row1 = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('team_view').setLabel('👁️ Voir mon équipe').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('team_edit').setLabel('📝 Modifier équipe').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('team_members').setLabel('👥 Gérer les membres').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('team_leaderboard').setLabel('📈 Voir le classement').setStyle(ButtonStyle.Secondary)
+  );
+  const row2 = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('team_search').setLabel('🔍 Voir une autre équipe').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('team_schedule').setLabel('🕹️ Programmer un match').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('team_disband').setLabel('❌ Dissoudre l\u2019équipe').setStyle(ButtonStyle.Danger)
+  );
+  await interaction.editReply({ embeds: [embed], components: [row1, row2] });
+}
+
 export function setupTeam(client) {
   client.once('ready', async () => {
     try {
       await client.application.commands.create({
         name: 'team',
-        description: 'Gérer les équipes Rocket League',
+        description: 'Gestion des équipes',
         options: [
-          { name: 'create', description: 'Créer une équipe', type: ApplicationCommandOptionType.Subcommand, options: [
-            { name: 'nom', description: 'Nom de la team', type: ApplicationCommandOptionType.String, required: true },
-            { name: 'description', description: 'Description de la team', type: ApplicationCommandOptionType.String, required: true }
-          ] },
-            { name: 'invite', description: 'Inviter un joueur', type: ApplicationCommandOptionType.Subcommand, options: [ { name: 'joueur', description: 'Joueur à inviter', type: ApplicationCommandOptionType.User, required: true }, { name: 'role', description: 'Rôle dans la team', type: ApplicationCommandOptionType.String, required: false, choices: [ { name: 'Membre', value: 'member' }, { name: 'Coach', value: 'coach' }, { name: 'Manager', value: 'manager' } ] } ] },
-          { name: 'join', description: 'Rejoindre une équipe', type: ApplicationCommandOptionType.Subcommand, options: [{ name: 'nom', description: 'Nom de la team', type: ApplicationCommandOptionType.String, required: true }] },
-          { name: 'leave', description: "Quitter l'équipe", type: ApplicationCommandOptionType.Subcommand },
-          { name: 'kick', description: 'Expulser un joueur', type: ApplicationCommandOptionType.Subcommand, options: [{ name: 'joueur', description: 'Joueur à kick', type: ApplicationCommandOptionType.User, required: true }] },
-          { name: 'disband', description: "Dissoudre l'équipe", type: ApplicationCommandOptionType.Subcommand },
-          { name: 'info', description: 'Info de la team', type: ApplicationCommandOptionType.Subcommand, options: [
-            { name: 'team', description: 'Nom de la team', type: ApplicationCommandOptionType.String, required: false }
-          ] },
-          { name: 'edit', description: 'Modifier la team', type: ApplicationCommandOptionType.Subcommand, options: [
-            { name: 'logo', description: 'URL du logo', type: ApplicationCommandOptionType.String, required: false }
-          ] },
-          { name: 'match', description: 'Programmer un match', type: ApplicationCommandOptionType.Subcommand, options: [{ name: 'equipe', description: 'Équipe adverse', type: ApplicationCommandOptionType.String, required: true }, { name: 'date', description: 'Date/heure', type: ApplicationCommandOptionType.String, required: true }] },
-          { name: 'report', description: 'Reporter un match', type: ApplicationCommandOptionType.Subcommand, options: [{ name: 'resultat', description: 'victoire ou défaite', type: ApplicationCommandOptionType.String, required: true, choices: [{ name: 'victoire', value: 'win' }, { name: 'défaite', value: 'loss' }] }, { name: 'score', description: 'Score', type: ApplicationCommandOptionType.String, required: true }] },
-          { name: 'leaderboard', description: 'Top équipes', type: ApplicationCommandOptionType.Subcommand }
+          { name: 'menu', description: 'Ouvrir le menu', type: ApplicationCommandOptionType.Subcommand }
         ]
       });
     } catch (err) {
@@ -121,271 +172,75 @@ export function setupTeam(client) {
   });
 
   client.on('interactionCreate', async interaction => {
-    if (!interaction.isChatInputCommand() || interaction.commandName !== 'team') return;
-    const sub = interaction.options.getSubcommand();
     try {
-      if (sub === 'create') {
-        await interaction.deferReply({ ephemeral: true });
-        const name = interaction.options.getString('nom');
-        const description = interaction.options.getString('description');
-        const existingTeam = await findTeamByUser(interaction.user.id);
-        if (existingTeam) {
-          await interaction.editReply({ content: "Vous faites déjà partie d'une équipe." });
-          return;
-        }
-        const exists = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(name)}` });
-        if (exists.length) {
-          await interaction.editReply({ content: 'Ce nom est déjà pris.' });
-          return;
-        }
-        const team = await sbRequest('POST', 'teams', { body: { name, description, captain_id: interaction.user.id, elo: 1000 } });
-        try {
-          await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: team[0].id } });
-        } catch (e) {
-          if (!String(e.message).includes('duplicate key')) throw e;
-        }
-        await createTeamResources(interaction, name);
-        const embed = new EmbedBuilder()
-          .setTitle('✅ Équipe créée avec succès !')
-          .setDescription(`🆕 Nom : **${name}**  \n👑 Capitaine : <@${interaction.user.id}>  \n👥 Membres : *(0/6)*\n\nℹ️ Tu peux maintenant inviter des joueurs avec :  \n\`/team invite @joueur\``)
-          .setColor('#a47864')
-          .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
-          .setTimestamp();
-        await interaction.editReply({ embeds: [embed] });
-      } else if (sub === 'invite') {
-        await interaction.deferReply({ ephemeral: true });
-        const user = interaction.options.getUser('joueur');
-        const team = await findTeamByUser(interaction.user.id);
-        const role = interaction.options.getString("role") || "member";
-        if (!team) {
-          await interaction.editReply({ content: "Vous ne possédez pas de team." });
-          return;
-        }
-        if (team.captain_id !== interaction.user.id) {
-          await interaction.editReply({ content: 'Seul le capitaine peut inviter.' });
-          return;
-        }
-        const members = await sbRequest('GET', 'team_members', { query: `team_id=eq.${team.id}` });
-        if (members.length >= 6) {
-          await interaction.editReply({ content: 'Équipe complète (6 membres max).' });
-          return;
-        }
-        await sbRequest('POST', 'team_invitations', { body: { team_id: team.id, user_id: user.id, status: 'pending', role } });
-        const embed = new EmbedBuilder()
-          .setTitle('🎟️ Invitation à rejoindre une équipe')
-          .setDescription(`<@${interaction.user.id}> t\u2019a invité à rejoindre l\u2019équipe **${team.name}** !\n\n🔹 Veux-tu rejoindre cette équipe et participer à des matchs classés ?\n\n✅ Réponds avec \`/team join ${team.name}\` pour accepter.`)
-          .setColor('#a47864')
-          .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
-          .setTimestamp();
-        try {
-          await user.send({ embeds: [embed] });
-        } catch {}
-        await interaction.editReply({ content: `${user} a été invité dans **${team.name}**.` });
-      } else if (sub === 'join') {
-        await interaction.deferReply({ ephemeral: true });
-        const memberOf = await findTeamByUser(interaction.user.id);
-        if (memberOf) {
-          await interaction.editReply({ content: "Vous faites déjà partie d'une équipe." });
-          return;
-        }
-        const name = interaction.options.getString('nom');
-        const teamRows = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(name)}` });
-        if (!teamRows.length) {
-          await interaction.editReply({ content: 'Équipe introuvable.' });
-          return;
-        }
-        const team = teamRows[0];
-        const inv = await sbRequest('GET', 'team_invitations', { query: `team_id=eq.${team.id}&user_id=eq.${interaction.user.id}&status=eq.pending` });
-        if (!inv.length) {
-          await interaction.editReply({ content: "Pas d'invitation pour cette équipe." });
-          return;
-        }
-        await sbRequest('PATCH', `team_invitations?id=eq.${inv[0].id}`, { body: { status: 'accepted' } });
-        const role = inv[0].role || "member";
-        if (role === "coach") {
-          await sbRequest("PATCH", `teams?id=eq.${team.id}`, { body: { coach_id: interaction.user.id } });
-        } else if (role === "manager") {
-          await sbRequest("PATCH", `teams?id=eq.${team.id}`, { body: { manager_id: interaction.user.id } });
-        } else {
-          try {
-            await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: team.id } });
-          } catch (e) {
-            if (!String(e.message).includes('duplicate key')) throw e;
-          }
-        }
-        let guild = interaction.guild;
-        let member = interaction.member;
-        if (!guild) {
-          try {
-            const data = JSON.parse(fs.readFileSync(CHANNEL_FILE, 'utf8'));
-            if (data.channelId) {
-              const ch = await client.channels.fetch(data.channelId).catch(() => null);
-              guild = ch?.guild || null;
-              member = guild ? await guild.members.fetch(interaction.user.id).catch(() => null) : null;
-            }
-          } catch {}
-        }
-        if (guild && member) {
-          const teamRole = guild.roles.cache.find(r => r.name === team.name);
-          if (teamRole) {
-            await member.roles.add(teamRole).catch(() => {});
-          }
-        }
-        await interaction.editReply(`Vous avez rejoint **${team.name}** !`);
-      } else if (sub === 'leave') {
-        await interaction.deferReply({ ephemeral: true });
-        const team = await findTeamByUser(interaction.user.id);
-        if (!team) {
-          await interaction.editReply({ content: "Vous ne faites partie d'aucune équipe." });
-          return;
-        }
-        await sbRequest('DELETE', `team_members?user_id=eq.${interaction.user.id}&team_id=eq.${team.id}`);
-        await interaction.editReply("Vous avez quitté l'équipe.");
-      } else if (sub === 'kick') {
-        await interaction.deferReply({ ephemeral: true });
-        const user = interaction.options.getUser('joueur');
-        const team = await findTeamByUser(interaction.user.id);
-        if (!team || team.captain_id !== interaction.user.id) {
-          await interaction.editReply({ content: 'Capitaine uniquement.' });
-          return;
-        }
-        await sbRequest('DELETE', `team_members?user_id=eq.${user.id}&team_id=eq.${team.id}`);
-        await interaction.editReply(`${user} a été expulsé.`);
-      } else if (sub === 'disband') {
-        await interaction.deferReply({ ephemeral: true });
-        const team = await findTeamByUser(interaction.user.id);
-        if (!team || team.captain_id !== interaction.user.id) {
-          await interaction.editReply({ content: 'Capitaine uniquement.' });
-          return;
-        }
-        await sbRequest('DELETE', `team_members?team_id=eq.${team.id}`);
-        await sbRequest('DELETE', `teams?id=eq.${team.id}`);
-        if (interaction.guild) {
-          const role = interaction.guild.roles.cache.find(r => r.name === team.name);
-          if (role) await role.delete().catch(() => {});
-          const category = interaction.guild.channels.cache.find(c => c.name === team.name && c.type === ChannelType.GuildCategory);
-          if (category) {
-            const children = interaction.guild.channels.cache.filter(ch => ch.parentId === category.id);
-            for (const ch of children.values()) await ch.delete().catch(() => {});
-            await category.delete().catch(() => {});
-          }
-        }
-        await interaction.editReply(`L'équipe **${team.name}** a été dissoute.`);
-      } else if (sub === 'info') {
-        await interaction.deferReply({ ephemeral: true });
-        const teamName = interaction.options.getString('team');
-        let team;
-        if (teamName) {
-          const rows = await sbRequest('GET', 'teams', { query: `name=ilike.${encodeURIComponent(teamName)}` });
-          if (!rows.length) {
-            const embed = new EmbedBuilder()
-              .setDescription(`❌ Équipe introuvable : aucun résultat pour “${teamName}”.`)
-              .setColor('#a47864')
-              .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
-              .setTimestamp();
-            await interaction.editReply({ embeds: [embed] });
-            return;
-          }
-          team = rows[0];
-        } else {
-          team = await findTeamByUser(interaction.user.id);
-          if (!team) {
-            await interaction.editReply({ content: 'Aucune équipe trouvée.' });
-            return;
-          }
-        }
-        const members = await sbRequest('GET', 'team_members', { query: `team_id=eq.${team.id}` });
-        const list = members.map(m => `> – <@${m.user_id}>`).join('\n');
-        const wins = (await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&winner=eq.${team.id}` })).length;
-        const losses = (await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&winner=neq.${team.id}` })).filter(m => m.winner).length;
-        const ratio = wins + losses ? Math.round((wins / (wins + losses)) * 100) : 0;
-        const lastRows = await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&order=id.desc&limit=1` });
-        let lastField = 'Aucun match enregistré.';
-        if (lastRows.length) {
-          const match = lastRows[0];
-          const opp = await sbRequest('GET', 'teams', { query: `id=eq.${match.team_b}` });
-          const oppName = opp[0]?.name || 'Inconnu';
-          const result = match.winner ? (match.winner === team.id ? 'Victoire' : 'Défaite') : 'Match en attente';
-          lastField = `vs ${oppName} → ${result} ${match.score || ''}`;
-          if (match.date) lastField += ` (${match.date})`;
-        }
-
-        const embed = new EmbedBuilder()
-          .setTitle(`📜 Équipe : **${team.name}**`);
-        if (team.description) embed.setDescription(`> ${team.description}`);
-        embed
-          .addFields(
-            { name: '• 👑 Capitaine', value: `> <@${team.captain_id}>`, inline: true },
-            { name: '• 🎓 Coach', value: team.coach_id ? `> <@${team.coach_id}>` : '> –', inline: true },
-            { name: '• 🧾 Manager', value: team.manager_id ? `> <@${team.manager_id}>` : '> –', inline: false },
-            { name: `• 👥 Membres (${members.length}/6)`, value: list || '> – Aucun', inline: true },
-            { name: '📊 Statistiques d’équipe', value: `> 🧠 Élo : ${team.elo}\n> 🏆 Victoires : ${wins}\n> ❌ Défaites : ${losses}\n> 🔄 Ratio de win : ${ratio}%`, inline: true },
-            { name: '• 🏅 Dernier match', value: lastField, inline: false }
-          )
-          .setColor('#a47864')
-          .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
-          .setTimestamp();
-        embed.setImage(team.logo || 'https://i.imgur.com/HczhXhK.png');
-        await interaction.editReply({ embeds: [embed] });
-      } else if (sub === 'edit') {
-        await interaction.deferReply({ ephemeral: true });
-        const team = await findTeamByUser(interaction.user.id);
-        if (!team || team.captain_id !== interaction.user.id) {
-          await interaction.editReply({ content: 'Capitaine uniquement.' });
-          return;
-        }
-        const logo = interaction.options.getString('logo');
-        const body = {};
-        if (logo !== null) body.logo = logo;
-        if (!Object.keys(body).length) {
-          await interaction.editReply({ content: 'Rien à modifier.' });
-          return;
-        }
-        const updated = await sbRequest('PATCH', `teams?id=eq.${team.id}`, { body });
-        await interaction.editReply({ content: 'Équipe mise à jour.' });
-      } else if (sub === 'match') {
-        await interaction.deferReply({ ephemeral: true });
-        const team = await findTeamByUser(interaction.user.id);
-        if (!team || team.captain_id !== interaction.user.id) {
-          await interaction.editReply({ content: 'Capitaine uniquement.' });
-          return;
-        }
-        const opponent = interaction.options.getString('equipe');
-        const date = interaction.options.getString('date');
-        const oppRows = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(opponent)}` });
-        if (!oppRows.length) {
-          await interaction.editReply({ content: 'Équipe adverse introuvable.' });
-          return;
-        }
-        await sbRequest('POST', 'match_history', { body: { team_a: team.id, team_b: oppRows[0].id, score: '', date } });
-        await interaction.editReply('Match programmé.');
-      } else if (sub === 'report') {
-        await interaction.deferReply({ ephemeral: true });
-        const result = interaction.options.getString('resultat');
-        const score = interaction.options.getString('score');
-        const team = await findTeamByUser(interaction.user.id);
-        if (!team) {
-          await interaction.editReply({ content: 'Aucune équipe trouvée.' });
-          return;
-        }
-        const last = await sbRequest('GET', 'match_history', { query: `team_a=eq.${team.id}&order=id.desc&limit=1` });
-        if (!last.length) {
-          await interaction.editReply({ content: 'Aucun match à reporter.' });
-          return;
-        }
-        await sbRequest('PATCH', `match_history?id=eq.${last[0].id}`, { body: { score, winner: result === 'win' ? team.id : last[0].team_b } });
-        await interaction.editReply('Résultat enregistré.');
-        } else if (sub === 'leaderboard') {
+      if (interaction.isChatInputCommand() && interaction.commandName === 'team') {
+        const sub = interaction.options.getSubcommand();
+        if (sub === 'menu') {
           await interaction.deferReply({ ephemeral: true });
+          await showMainMenu(interaction);
+        }
+        return;
+      }
+
+      if (interaction.isButton()) {
+        if (interaction.customId === 'team_view') {
+          await interaction.deferUpdate();
+          await showMainMenu(interaction);
+        } else if (interaction.customId === 'team_create') {
+          const modal = new ModalBuilder()
+            .setTitle('Créer une équipe')
+            .setCustomId('team_create_modal')
+            .addComponents(
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId('name').setLabel('Nom').setStyle(TextInputStyle.Short).setRequired(true)),
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId('desc').setLabel('Description').setStyle(TextInputStyle.Paragraph).setRequired(true))
+            );
+          await interaction.showModal(modal);
+        } else if (interaction.customId === 'team_join') {
+          const modal = new ModalBuilder()
+            .setTitle('Rejoindre une équipe')
+            .setCustomId('team_join_modal')
+            .addComponents(
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId('name').setLabel('Nom de l\u2019équipe').setStyle(TextInputStyle.Short).setRequired(true))
+            );
+          await interaction.showModal(modal);
+        } else if (interaction.customId === 'team_edit') {
+          const menu = new StringSelectMenuBuilder()
+            .setCustomId('team_edit_select')
+            .setPlaceholder('Que souhaites-tu modifier ?')
+            .addOptions(
+              { label: 'Nom', value: 'name' },
+              { label: 'Logo', value: 'logo' },
+              { label: 'Bio', value: 'bio' },
+              { label: 'Description', value: 'description' }
+            );
+          await interaction.reply({ components: [new ActionRowBuilder().addComponents(menu)], ephemeral: true });
+        } else if (interaction.customId === 'team_members') {
+          const team = await findTeamByUser(interaction.user.id);
+          if (!team || team.captain_id !== interaction.user.id) {
+            await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
+            return;
+          }
+          const members = await sbRequest('GET', 'team_members', { query: `team_id=eq.${team.id}` });
+          const rows = [];
+          for (const m of members) {
+            const row = new ActionRowBuilder().addComponents(
+              new ButtonBuilder().setCustomId(`team_kick_${m.user_id}`).setLabel(`Kick <@${m.user_id}>`).setStyle(ButtonStyle.Danger),
+              new ButtonBuilder().setCustomId(`team_promote_${m.user_id}`).setLabel('Promouvoir').setStyle(ButtonStyle.Secondary)
+            );
+            rows.push(row);
+          }
+          const embed = new EmbedBuilder()
+            .setTitle('Membres de l\u2019équipe')
+            .setDescription(members.map(m => `<@${m.user_id}>`).join('\n'))
+            .setColor('#a47864');
+          await interaction.reply({ embeds: [embed], components: rows, ephemeral: true });
+        } else if (interaction.customId === 'team_leaderboard') {
           const rows = await sbRequest('GET', 'teams', { query: 'order=elo.desc&limit=5' });
           const embed = new EmbedBuilder()
             .setTitle('🏆 Classement des équipes — Saison Alpha')
             .setDescription('> 📊 Classement compétitif des équipes en temps réel.')
-            .setImage('https://i.imgur.com/oyQE5I0.png')
             .setColor('#a47864')
-            .setFooter({ text: 'Auusa.gg - Connecté. Compétitif. Collectif.', iconURL: 'https://i.imgur.com/9FLBUiC.png' })
-            .setTimestamp();
-
+            .setImage('https://i.imgur.com/oyQE5I0.png');
           const medals = ['🥇', '🥈', '🥉'];
           for (let i = 0; i < rows.length; i++) {
             const t = rows[i];
@@ -393,14 +248,132 @@ export function setupTeam(client) {
             const losses = (await sbRequest('GET', 'match_history', { query: `team_a=eq.${t.id}&winner=neq.${t.id}` })).filter(m => m.winner).length;
             const ratio = wins + losses ? Math.round((wins / (wins + losses)) * 100) : 0;
             const icon = medals[i] || '🔹';
-            embed.addFields({
-              name: `• ${icon} ${i + 1}. ${t.name}`,
-              value: `> 💠 Élo : ${t.elo} — 🏆 V : ${wins} — ❌ D : ${losses} — 📊 ${ratio}%`,
-              inline: false
-            });
+            embed.addFields({ name: `• ${icon} ${i + 1}. ${t.name}`, value: `> 💠 Élo : ${t.elo} — 🏆 V : ${wins} — ❌ D : ${losses} — 📊 ${ratio}%`, inline: false });
           }
-
-          await interaction.editReply({ embeds: [embed] });
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+        } else if (interaction.customId === 'team_search') {
+          const modal = new ModalBuilder()
+            .setTitle('Rechercher une équipe')
+            .setCustomId('team_search_modal')
+            .addComponents(
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId('name').setLabel('Nom de l\u2019équipe').setStyle(TextInputStyle.Short).setRequired(true))
+            );
+          await interaction.showModal(modal);
+        } else if (interaction.customId === 'team_schedule') {
+          const modal = new ModalBuilder()
+            .setTitle('Programmer un match')
+            .setCustomId('team_schedule_modal')
+            .addComponents(
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId('opponent').setLabel('Équipe adverse').setStyle(TextInputStyle.Short).setRequired(true)),
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId('date').setLabel('Date/heure').setStyle(TextInputStyle.Short).setRequired(true))
+            );
+          await interaction.showModal(modal);
+        } else if (interaction.customId === 'team_disband') {
+          const row = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('team_disband_confirm').setLabel('Confirmer').setStyle(ButtonStyle.Danger),
+            new ButtonBuilder().setCustomId('team_disband_cancel').setLabel('Annuler').setStyle(ButtonStyle.Secondary)
+          );
+          await interaction.reply({ content: 'Confirmer la dissolution ?', components: [row], ephemeral: true });
+        } else if (interaction.customId === 'team_disband_confirm') {
+          const team = await findTeamByUser(interaction.user.id);
+          if (!team || team.captain_id !== interaction.user.id) {
+            await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
+            return;
+          }
+          await sbRequest('DELETE', `team_members?team_id=eq.${team.id}`);
+          await sbRequest('DELETE', `teams?id=eq.${team.id}`);
+          if (interaction.guild) {
+            const role = interaction.guild.roles.cache.find(r => r.name === team.name);
+            if (role) await role.delete().catch(() => {});
+            const category = interaction.guild.channels.cache.find(c => c.name === team.name && c.type === ChannelType.GuildCategory);
+            if (category) {
+              const children = interaction.guild.channels.cache.filter(ch => ch.parentId === category.id);
+              for (const ch of children.values()) await ch.delete().catch(() => {});
+              await category.delete().catch(() => {});
+            }
+          }
+          await interaction.update({ content: `L\u2019équipe **${team.name}** a été dissoute.`, components: [] });
+        } else if (interaction.customId === 'team_disband_cancel') {
+          await interaction.update({ content: 'Action annulée.', components: [] });
+        } else if (interaction.customId.startsWith('team_kick_')) {
+          const userId = interaction.customId.split('_')[2];
+          const team = await findTeamByUser(interaction.user.id);
+          if (!team || team.captain_id !== interaction.user.id) {
+            await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
+            return;
+          }
+          await sbRequest('DELETE', `team_members?user_id=eq.${userId}&team_id=eq.${team.id}`);
+          await interaction.reply({ content: `<@${userId}> a été expulsé.`, ephemeral: true });
+        } else if (interaction.customId.startsWith('team_promote_')) {
+          const userId = interaction.customId.split('_')[2];
+          const team = await findTeamByUser(interaction.user.id);
+          if (!team || team.captain_id !== interaction.user.id) {
+            await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
+            return;
+          }
+          await sbRequest('PATCH', `teams?id=eq.${team.id}`, { body: { captain_id: userId } });
+          await interaction.reply({ content: `<@${userId}> est maintenant capitaine.`, ephemeral: true });
+        }
+      } else if (interaction.isStringSelectMenu()) {
+        if (interaction.customId === 'team_edit_select') {
+          const value = interaction.values[0];
+          const modal = new ModalBuilder()
+            .setTitle('Modifier la team')
+            .setCustomId(`team_edit_${value}`)
+            .addComponents(
+              new ActionRowBuilder().addComponents(new TextInputBuilder().setCustomId(value).setLabel(`Nouveau ${value}`).setStyle(TextInputStyle.Short).setRequired(true))
+            );
+          await interaction.showModal(modal);
+        }
+      } else if (interaction.isModalSubmit()) {
+        if (interaction.customId === 'team_create_modal') {
+          const name = interaction.fields.getTextInputValue('name');
+          const desc = interaction.fields.getTextInputValue('desc');
+          const existingTeam = await findTeamByUser(interaction.user.id);
+          if (existingTeam) return interaction.reply({ content: 'Déjà dans une équipe.', ephemeral: true });
+          const exists = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(name)}` });
+          if (exists.length) return interaction.reply({ content: 'Nom déjà pris.', ephemeral: true });
+          const team = await sbRequest('POST', 'teams', { body: { name, description: desc, captain_id: interaction.user.id, elo: 1000 } });
+          await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: team[0].id } }).catch(() => {});
+          await createTeamResources(interaction, name);
+          await interaction.reply({ content: 'Équipe créée !', ephemeral: true });
+        } else if (interaction.customId === 'team_join_modal') {
+          const name = interaction.fields.getTextInputValue('name');
+          const rows = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(name)}` });
+          if (!rows.length) return interaction.reply({ content: 'Équipe introuvable.', ephemeral: true });
+          await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: rows[0].id } }).catch(() => {});
+          await interaction.reply({ content: `Rejoint **${rows[0].name}** !`, ephemeral: true });
+        } else if (interaction.customId.startsWith('team_edit_')) {
+          const field = interaction.customId.replace('team_edit_', '');
+          const value = interaction.fields.getTextInputValue(field);
+          const team = await findTeamByUser(interaction.user.id);
+          if (!team || team.captain_id !== interaction.user.id) {
+            await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
+            return;
+          }
+          const body = {};
+          body[field] = value;
+          await sbRequest('PATCH', `teams?id=eq.${team.id}`, { body });
+          await interaction.reply({ content: 'Équipe mise à jour.', ephemeral: true });
+        } else if (interaction.customId === 'team_search_modal') {
+          const name = interaction.fields.getTextInputValue('name');
+          const rows = await sbRequest('GET', 'teams', { query: `name=ilike.${encodeURIComponent(name)}` });
+          if (!rows.length) return interaction.reply({ content: 'Équipe introuvable.', ephemeral: true });
+          const embed = await buildTeamEmbed(rows[0]);
+          await interaction.reply({ embeds: [embed], ephemeral: true });
+        } else if (interaction.customId === 'team_schedule_modal') {
+          const opponent = interaction.fields.getTextInputValue('opponent');
+          const date = interaction.fields.getTextInputValue('date');
+          const team = await findTeamByUser(interaction.user.id);
+          if (!team || team.captain_id !== interaction.user.id) {
+            await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
+            return;
+          }
+          const oppRows = await sbRequest('GET', 'teams', { query: `name=eq.${encodeURIComponent(opponent)}` });
+          if (!oppRows.length) return interaction.reply({ content: 'Équipe adverse introuvable.', ephemeral: true });
+          await sbRequest('POST', 'match_history', { body: { team_a: team.id, team_b: oppRows[0].id, score: '', date } });
+          await interaction.reply({ content: 'Match programmé.', ephemeral: true });
+        }
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Résumé
- refonte complète de `team.js` pour supprimer les sous‑commandes
- ajout d'un seul point d'entrée `/team menu`
- intégration d'embeds, boutons, modals et select menus pour gérer une équipe

## Test
- `npm install`
- `npm test` *(échec attendu : script absent)*

------
https://chatgpt.com/codex/tasks/task_e_688c32ce8c58832ca0009d29c9b17533