### PR TITLE
Improve Supabase error handling

### DIFF
--- a/bot/advancedMatchmaking.js
+++ b/bot/advancedMatchmaking.js
@@ -12,27 +12,43 @@ const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_KEY;
 
 async function sbRequest(method, table, { query = '', body } = {}) {
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    throw new Error('SUPABASE_URL et SUPABASE_KEY doivent être définies');
+  }
+  if (method === 'POST' && !query) {
+    query = 'select=*';
+  }
   const url = `${SUPABASE_URL}/rest/v1/${table}${query ? `?${query}` : ''}`;
-  const res = await fetch(url, {
-    method,
-    headers: {
-      apikey: SUPABASE_KEY,
-      Authorization: `Bearer ${SUPABASE_KEY}`,
-      'Content-Type': 'application/json',
-      Prefer: 'return=representation'
-    },
-    body: body ? JSON.stringify(body) : undefined
-  });
+  let res;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: {
+        apikey: SUPABASE_KEY,
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation'
+      },
+      body: body ? JSON.stringify(body) : undefined
+    });
+  } catch (err) {
+    throw new Error(`Échec de la requête vers Supabase: ${err.message}`);
+  }
   if (!res.ok) {
     let msg;
     try {
-      msg = (await res.json()).message;
+      const data = await res.json();
+      msg = data.message || JSON.stringify(data);
     } catch {
-      msg = res.statusText;
+      msg = await res.text();
     }
-    throw new Error(msg);
+    throw new Error(`Supabase ${method} ${table} ${res.status} : ${msg}`);
   }
-  return res.json();
+  try {
+    return await res.json();
+  } catch (err) {
+    throw new Error(`Réponse invalide de Supabase : ${err.message}`);
+  }
 }
 
 const activeMatches = new Map(); // matchId -> data


### PR DESCRIPTION
## Summary
- clarify errors when Supabase credentials are missing or fetch fails in `sbRequest`
- add detailed status text when Supabase responds with an error
- return inserted rows by default on POST requests

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688c3c4afa1c832cbc0dc9c0d7819b35