### PR TITLE
feat: update matchmaking server ip

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -428,7 +428,7 @@ void MatchmakingPlugin::OnGameEnd()
         {
             try
             {
-                cpr::Post(cpr::Url{"http://localhost:3000/match"},
+                cpr::Post(cpr::Url{"http://34.32.118.126:3000/match"},
                           cpr::Body{p.dump()},
                           cpr::Header{{"Content-Type", "application/json"}});
             }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -17,7 +17,7 @@ affiché dans la console BakkesMod avec le nom du joueur et le temps de jeu.
 
 ## Fonctionnement
 
-Le plugin récupère les informations de fin de match et les envoie au bot Discord via une requête HTTP POST.
+Le plugin récupère les informations de fin de match et les envoie au bot Discord via une requête HTTP POST vers `http://34.32.118.126:3000`.
 Il transmet notamment :
 
 - le score global des équipes ;


### PR DESCRIPTION
## Summary
- send match stats to new IP instead of localhost
- document target server in plugin README

## Testing
- `g++ -fsyntax-only plugin/MatchmakingPlugin.cpp` (fails: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)
- `npm test` in bot (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688d9bfcbff8832c88eb2e1ab570cfbe