### PR TITLE
fix: corriger la signature du callback SetTimeout

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -422,7 +422,7 @@ void MatchmakingPlugin::OnGameEnd()
     if (debugEnabled)
         Log("[DEBUG] Envoi des stats : " + std::to_string(players.size()) + " joueurs");
 
-    gameWrapper->SetTimeout([payload = std::move(payload)]() mutable
+    gameWrapper->SetTimeout([payload = std::move(payload)](GameWrapper* /*gw*/) mutable
     {
         std::thread([p = std::move(payload)]() mutable
         {


### PR DESCRIPTION
## Summary
- corriger la signature du callback `SetTimeout`

## Testing
- `g++ -std=c++17 -fsyntax-only plugin/MatchmakingPlugin.cpp` *(échoue: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688d9ffb8f6c832cb45f9ec99fb64c64