### PR TITLE
Fix match recap buttons showing 'Données indisponibles'

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -241,6 +241,7 @@ app.post('/match', async (req, res) => {
     const row = new ActionRowBuilder().addComponents(btn, teamBtn, faceBtn);
 
     const message = await channel.send({ embeds: [embed], components: [row] });
+    matchData.set(message.id, players);
     await handleMatchResult(req.body, client);
   }
   res.sendStatus(200);


### PR DESCRIPTION
## Summary
- conserve les données du match afin que les boutons d'analyse puissent récupérer les statistiques des joueurs

## Testing
- `npm test` *(échoue : Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688da5c573a8832c9b0265e0c867738d