### PR TITLE
Assure la présence d'une description dans les embeds

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -257,6 +257,9 @@ async function handleBroadcast(interaction) {
   let embedData;
   try {
     embedData = JSON.parse(embedJson);
+    if (typeof embedData.description !== 'string') {
+      embedData.description = '';
+    }
   } catch (err) {
     await interaction.editReply({ content: 'Embed JSON invalide.' });
     return;


### PR DESCRIPTION
## Résumé
- Définit une description vide par défaut lors de l'analyse JSON afin d'éviter les erreurs d'embed Discord.

## Tests
- `npm test` *(échoue : Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dbc510ed4832c8f9087b623af004f