### PR TITLE
Fix broadcast embed description handling

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -257,8 +257,8 @@ async function handleBroadcast(interaction) {
   let embedData;
   try {
     embedData = JSON.parse(embedJson);
-    if (typeof embedData.description !== 'string') {
-      embedData.description = '';
+    if (typeof embedData.description !== 'string' || embedData.description.trim() === '') {
+      embedData.description = '\u200B';
     }
   } catch (err) {
     await interaction.editReply({ content: 'Embed JSON invalide.' });
@@ -306,7 +306,6 @@ async function handleBroadcast(interaction) {
         return;
       }
     }
-    if (msg) sentTo.push(t.name);
   }
 
   const logChannel = guild.channels.cache.find(c => c.name.includes('logs-broadcasts'));


### PR DESCRIPTION
## Summary
- ensure broadcast embeds always have a valid description
- remove stray `msg` reference after message send loop

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688de2f75d08832caf34f002ac5ac634