### PR TITLE
Détection automatique des salons 1v1/2v2 via nom de channel

### DIFF
--- a/bot/matchmaking.js
+++ b/bot/matchmaking.js
@@ -9,8 +9,8 @@ import {
 
 export function setupMatchmaking(client) {
   const modes = {
-    '🎮 Ranked 1v1': 2,
-    '🎮 Ranked 2v2': 4,
+    '1v1': 2,
+    '2v2': 4,
   };
   const banRoleName = '🚫 Banni Ranked';
   const bakkesRole = '🧩 BakkesMod';
@@ -28,8 +28,11 @@ export function setupMatchmaking(client) {
   }, 60 * 1000);
 
   client.on('voiceStateUpdate', async (oldState, newState) => {
-    if (!newState.channel || !modes[newState.channel.name]) return;
-    const required = modes[newState.channel.name];
+    if (!newState.channel) return;
+    const name = newState.channel.name;
+    const mode = Object.keys(modes).find(k => name.includes(k));
+    if (!mode) return;
+    const required = modes[mode];
     const members = newState.channel.members.filter(m => !m.user.bot);
     if (members.size === required) {
       startMatch(newState.channel, [...members.values()]);


### PR DESCRIPTION
## Résumé
- Recherche du mode (1v1 ou 2v2) d'un salon vocal par inclusion dans son nom
- Démarrage automatique du match lorsque le nombre de joueurs requis est atteint

## Tests
- `npm test` (échec attendu : aucun script "test" défini)


------
https://chatgpt.com/codex/tasks/task_e_688de9142774832ca42e8f600902333b