### PR TITLE
Handle missing match category for channel creation

### DIFF
--- a/bot/matchmaking.js
+++ b/bot/matchmaking.js
@@ -15,7 +15,7 @@ export function setupMatchmaking(client) {
   const banRoleName = '🚫 Banni Ranked';
   const bakkesRole = '🧩 BakkesMod';
   const consoleRole = 'Console';
-  const MATCH_CATEGORY_ID = '1400845391238398112';
+  const MATCH_CATEGORY_ID = process.env.MATCH_CATEGORY_ID;
   const bans = new Map(); // userId -> {count}
   let matchCounter = 0;
 
@@ -44,11 +44,12 @@ export function setupMatchmaking(client) {
     const guild = channel.guild;
     const modRole = guild.roles.cache.find(r => /mod/i.test(r.name));
     const banRole = guild.roles.cache.find(r => r.name === banRoleName);
+    const parent = MATCH_CATEGORY_ID && guild.channels.cache.has(MATCH_CATEGORY_ID) ? MATCH_CATEGORY_ID : undefined;
 
     const privateVocal = await guild.channels.create({
       name: `🔐 Ranked Match #${matchCounter}`,
       type: ChannelType.GuildVoice,
-      parent: MATCH_CATEGORY_ID,
+      ...(parent ? { parent } : {}),
       permissionOverwrites: [
         { id: guild.roles.everyone, deny: PermissionsBitField.Flags.Connect },
         ...players.map(p => ({ id: p.id, allow: PermissionsBitField.Flags.Connect })),
@@ -59,7 +60,7 @@ export function setupMatchmaking(client) {
     const privateText = await guild.channels.create({
       name: `ranked-match-${matchCounter}`,
       type: ChannelType.GuildText,
-      parent: MATCH_CATEGORY_ID,
+      ...(parent ? { parent } : {}),
       permissionOverwrites: [
         { id: guild.roles.everyone, deny: PermissionsBitField.Flags.ViewChannel },
         ...players.map(p => ({ id: p.id, allow: PermissionsBitField.Flags.ViewChannel })),


### PR DESCRIPTION
## Summary
- use `MATCH_CATEGORY_ID` env var for match channels
- create channels even if category is missing by checking cache first

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688deb2054b0832cacea9a6cc7525b0c