### PR TITLE
Améliore les requêtes Supabase

### DIFF
--- a/bot/advancedMatchmaking.js
+++ b/bot/advancedMatchmaking.js
@@ -26,10 +26,17 @@ async function sbRequest(method, table, { query = '', body } = {}) {
   if (!SUPABASE_URL || !SUPABASE_KEY) {
     throw new Error('SUPABASE_URL et SUPABASE_KEY doivent être définies');
   }
-  if (method === 'POST' && !query) {
-    query = 'select=*';
+  let path = table;
+  const idx = table.indexOf('?');
+  if (idx !== -1) {
+    const existing = table.slice(idx + 1);
+    path = table.slice(0, idx);
+    query = query ? `${existing}&${query}` : existing;
   }
-  const url = `${BASE_URL}/rest/v1/${table}${query ? `?${query}` : ''}`;
+  if ((method === 'POST' || method === 'PATCH') && !/select=/i.test(query)) {
+    query = query ? `${query}&select=*` : 'select=*';
+  }
+  const url = `${BASE_URL}/rest/v1/${path}${query ? `?${query}` : ''}`;
   let res;
   try {
     res = await fetch(url, {

--- a/bot/registration.js
+++ b/bot/registration.js
@@ -5,7 +5,17 @@ const SUPABASE_KEY = process.env.SUPABASE_KEY;
 const BASE_URL = SUPABASE_URL?.replace(/\/rest\/v1\/?$/, '');
 
 async function sbRequest(method, table, { query = '', body } = {}) {
-  const url = `${BASE_URL}/rest/v1/${table}${query ? `?${query}` : ''}`;
+  let path = table;
+  const idx = table.indexOf('?');
+  if (idx !== -1) {
+    const existing = table.slice(idx + 1);
+    path = table.slice(0, idx);
+    query = query ? `${existing}&${query}` : existing;
+  }
+  if ((method === 'POST' || method === 'PATCH') && !/select=/i.test(query)) {
+    query = query ? `${query}&select=*` : 'select=*';
+  }
+  const url = `${BASE_URL}/rest/v1/${path}${query ? `?${query}` : ''}`;
   const res = await fetch(url, {
     method,
     headers: {

--- a/bot/team.js
+++ b/bot/team.js
@@ -27,7 +27,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CHANNEL_FILE = path.join(__dirname, 'channel.json');
 
 async function sbRequest(method, table, { query = '', body } = {}) {
-  const url = `${BASE_URL}/rest/v1/${table}${query ? `?${query}` : ''}`;
+  let path = table;
+  const idx = table.indexOf('?');
+  if (idx !== -1) {
+    const existing = table.slice(idx + 1);
+    path = table.slice(0, idx);
+    query = query ? `${existing}&${query}` : existing;
+  }
+  if ((method === 'POST' || method === 'PATCH') && !/select=/i.test(query)) {
+    query = query ? `${query}&select=*` : 'select=*';
+  }
+  const url = `${BASE_URL}/rest/v1/${path}${query ? `?${query}` : ''}`;
   const res = await fetch(url, {
     method,
     headers: {


### PR DESCRIPTION
## Résumé
- Gère correctement les requêtes vers Supabase en séparant table et paramètres.
- Ajoute `select=*` par défaut pour les opérations POST et PATCH.

## Tests
- `npm test` (échoue : Missing script "test")
- `node --check bot/advancedMatchmaking.js`
- `node --check bot/registration.js`
- `node --check bot/team.js`


------
https://chatgpt.com/codex/tasks/task_e_688df683bbc8832c9052c418366752f3