### PR TITLE
Fix Supabase RL credential field names

### DIFF
--- a/bot/advancedMatchmaking.js
+++ b/bot/advancedMatchmaking.js
@@ -253,7 +253,7 @@ export function setupAdvancedMatchmaking(client) {
         return interaction.reply({ content: 'Seul l\'hôte peut utiliser cette commande.', ephemeral: true });
       const name = interaction.options.getString('nom');
       const pwd = interaction.options.getString('password');
-      await sbRequest('PATCH', `match_sessions?id=eq.${matchId}`, { body: { RL_name: name, RL_password: pwd, status: 'ready' } }).catch(() => {});
+      await sbRequest('PATCH', `match_sessions?id=eq.${matchId}`, { body: { rl_name: name, rl_password: pwd, status: 'ready' } }).catch(() => {});
       await interaction.reply({ content: 'Infos enregistrées.', ephemeral: true });
       const text = interaction.channel;
       if (text)


### PR DESCRIPTION
### Summary
- use correct lowercase `rl_name` and `rl_password` when updating match sessions

### Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e5536cc6c832ca86530b4d2f86854