### PR TITLE
Corrige la condition de requête Supabase

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -256,7 +256,10 @@ void MatchmakingPlugin::LoadConfig()
 void MatchmakingPlugin::PollSupabase()
 {
     gameWrapper->SetTimeout(std::bind(&MatchmakingPlugin::PollSupabase, this), 3.0f);
-    if (gameWrapper->IsInGame())
+    // Ne pas interroger Supabase si l'on est déjà dans une partie en ligne.
+    // `IsInGame()` renvoie également vrai en entraînement ou en freeplay,
+    // ce qui empêchait toute requête lorsqu'on attendait dans ces modes.
+    if (gameWrapper->IsInOnlineGame())
         return;
 
     std::string playerId = cvarManager->getCvar("mm_player_id").getStringValue();


### PR DESCRIPTION
## Résumé
- Interroge Supabase tant que le joueur n'est pas en match en ligne

## Tests
- `g++ -fsyntax-only plugin/MatchmakingPlugin.cpp` *(échoue: bakkesmod/plugin/bakkesmodplugin.h manquant)*

------
https://chatgpt.com/codex/tasks/task_e_688ed92a2764832c994479a203b87d39