### PR TITLE
Remove duplicate PollSupabase call

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -249,8 +249,6 @@ void MatchmakingPlugin::LoadConfig()
     Log(" - URL: " + supabaseUrl);
     Log(" - API Key: " + supabaseApiKey.substr(0, 10) + "...");
     Log(" - JWT: " + supabaseJwt.substr(0, 10) + "...");
-
-    PollSupabase();
 }
 
 void MatchmakingPlugin::PollSupabase()


### PR DESCRIPTION
## Summary
- remove extra PollSupabase invocation during config loading so it only runs once after initialization

## Testing
- `bash build_plugin.bat` *(fails: `command not found` etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688ee2f4f164832ca6b237eaa656cfc1