### PR TITLE
feat: journaliser les retours de PollSupabase

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -260,13 +260,22 @@ void MatchmakingPlugin::PollSupabase()
     // `IsInGame()` renvoie également vrai en entraînement ou en freeplay,
     // ce qui empêchait toute requête lorsqu'on attendait dans ces modes.
     if (gameWrapper->IsInOnlineGame())
+    {
+        Log("[Supabase] Requête ignorée : déjà en partie en ligne");
         return;
+    }
 
     std::string playerId = cvarManager->getCvar("mm_player_id").getStringValue();
     if (playerId.empty() || playerId == "unknown")
+    {
+        Log("[Supabase] player_id manquant, requête annulée");
         return;
+    }
     if (supabaseUrl.empty() || supabaseApiKey.empty() || supabaseJwt.empty())
+    {
+        Log("[Supabase] Configuration Supabase incomplète");
         return;
+    }
 
     std::thread([this, playerId]() {
         try
@@ -274,15 +283,24 @@ void MatchmakingPlugin::PollSupabase()
             auto headers = cpr::Header{{"Authorization", "Bearer " + supabaseJwt}, {"apikey", supabaseApiKey}};
             cpr::Response r = cpr::Get(cpr::Url{supabaseUrl}, cpr::Parameters{{"player_id", "eq." + playerId}}, headers);
             if (r.status_code != 200)
+            {
+                Log("[Supabase] Erreur HTTP " + std::to_string(r.status_code) + ": " + r.text);
                 return;
+            }
             auto arr = json::parse(r.text, nullptr, false);
             if (!arr.is_array() || arr.empty())
+            {
+                Log("[Supabase] Réponse JSON vide ou invalide: " + r.text);
                 return;
+            }
             auto instr = arr.at(0);
             std::string name = instr.value("rl_name", "");
             std::string password = instr.value("rl_password", "");
             if (name.empty())
+            {
+                Log("[Supabase] Champ rl_name absent, aucune création de partie");
                 return;
+            }
             lastSupabaseName = name;
             lastSupabasePassword = password;
             Log("[Supabase] rl_name=" + name + ", rl_password=" + password);
@@ -301,9 +319,13 @@ void MatchmakingPlugin::PollSupabase()
 
             cpr::Delete(cpr::Url{supabaseUrl}, cpr::Parameters{{"player_id", "eq." + playerId}}, headers);
         }
+        catch (const std::exception& e)
+        {
+            Log(std::string("[Supabase] Exception: ") + e.what());
+        }
         catch (...)
         {
-            // Ignore errors
+            Log("[Supabase] Exception inconnue lors de la requête");
         }
     }).detach();
 }


### PR DESCRIPTION
## Summary
- log the reasons for early exits in `PollSupabase`
- report HTTP errors and empty JSON responses when querying Supabase
- log thrown exceptions during Supabase polling

## Testing
- `g++ -std=c++17 -c plugin/MatchmakingPlugin.cpp` *(fails: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688ee2f3986c832ca6c0cc6727d4568c