### PR TITLE
Log missing player ID

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -264,7 +264,10 @@ void MatchmakingPlugin::PollSupabase()
 
     std::string playerId = cvarManager->getCvar("mm_player_id").getStringValue();
     if (playerId.empty() || playerId == "unknown")
+    {
+        Log("mm_player_id manquant ou \"unknown\". Configurez-le via la commande mm_player_id <votre_id>");
         return;
+    }
     if (supabaseUrl.empty() || supabaseApiKey.empty() || supabaseJwt.empty())
         return;
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -24,6 +24,13 @@ Il doit contenir les champs suivants :
 
 Lors du chargement, le plugin lit ce fichier et utilise les valeurs pour contacter Supabase.
 
+Le cvar `mm_player_id` doit également être configuré avec l'identifiant du joueur. Cela peut se faire via la console BakkesMod :
+
+```
+mm_player_id VOTRE_ID_SUPABASE
+```
+
+
 ## Debug
 
 Le plugin expose le cvar `mm_debug` (0 ou 1). Lorsqu'il est activé, chaque \


### PR DESCRIPTION
## Summary
- consigne un avertissement si `mm_player_id` est vide ou "unknown" et propose une commande de configuration
- documente l'utilisation de `mm_player_id` dans le README

## Testing
- `g++ -std=c++17 -fsyntax-only plugin/MatchmakingPlugin.cpp` *(échoue : bakkesmodplugin.h manquant)*

------
https://chatgpt.com/codex/tasks/task_e_688ee2f59d5c832c80fe96f28feea992