### PR TITLE
Mise à jour des identifiants d'événements BakkesMod

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -331,24 +331,24 @@ void MatchmakingPlugin::PollSupabase()
 void MatchmakingPlugin::HookEvents()
 {
     gameWrapper->HookEventWithCallerPost<ServerWrapper>(
-        "Function TAGame.GameEvent_Soccar_TA.EventMatchStarted",
+        "Function TAGame.GameEvent_Soccar_TA.OnGameStarted",
         std::bind(&MatchmakingPlugin::OnMatchStart, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     gameWrapper->HookEventPost(
-        "Function TAGame.GameEvent_Soccar_TA.EventMatchEnded",
+        "Function TAGame.GameEvent_Soccar_TA.OnGameEnded",
         std::bind(&MatchmakingPlugin::OnGameEnd, this));
 
     gameWrapper->HookEventWithCallerPost<CarWrapper>(
-        "Function TAGame.Car_TA.EventHitBall",
+        "Function TAGame.Car_TA.OnHitBall",
         std::bind(&MatchmakingPlugin::OnHitBall, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     gameWrapper->HookEventWithCallerPost<CarWrapper>(
-        "Function TAGame.Car_TA.EventDemolish",
+        "Function TAGame.Car_TA.OnDemolished",
         std::bind(&MatchmakingPlugin::OnCarDemolish, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
     gameWrapper->HookEventWithCallerPost<CarWrapper>(
-        "Function TAGame.CarComponent_Boost_TA.OnPickup",
+        "Function TAGame.CarComponent_Boost_TA.OnBoostCollected",
         std::bind(&MatchmakingPlugin::OnBoostCollected, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 


### PR DESCRIPTION
## Résumé
- Mise à jour des noms d'événements hookés pour correspondre aux nouveaux identifiants du SDK BakkesMod

## Tests
- `g++ -std=c++17 -I/tmp/BakkesModSDK/include -c plugin/MatchmakingPlugin.cpp -o /tmp/MatchmakingPlugin.o` *(échoué : bakkesmod/wrappers/CVarManagerWrapper.h absent)*

------
https://chatgpt.com/codex/tasks/task_e_688ee6396d1c832ca78be0efa1f8bc9e