### PR TITLE
feat: rendre l'url du bot configurable

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -158,6 +158,7 @@ private:
     std::string lastSupabaseName;
     std::string lastSupabasePassword;
     bool supabaseDisabled = false;
+    std::string botEndpoint = "http://localhost:3000/match";
 };
 
 static PriWrapper GetPriByName(ServerWrapper server, const std::string& name)
@@ -326,6 +327,7 @@ void MatchmakingPlugin::LoadConfig()
     jwtExpiry = ParseJwtExpiry(supabaseJwt);
     if (jwtExpiry == 0)
         Log("[Config] Date d'expiration du JWT introuvable");
+    botEndpoint = cfg.value("BOT_ENDPOINT", "http://localhost:3000/match");
 }
 
 void MatchmakingPlugin::PollSupabase()
@@ -731,13 +733,13 @@ void MatchmakingPlugin::OnGameEnd()
     if (debugEnabled)
         Log("[DEBUG] Envoi des stats : " + std::to_string(players.size()) + " joueurs");
 
-    gameWrapper->SetTimeout([payload = std::move(payload)](GameWrapper* /*gw*/) mutable
+    gameWrapper->SetTimeout([payload = std::move(payload), url = botEndpoint](GameWrapper* /*gw*/) mutable
     {
-        std::thread([p = std::move(payload)]() mutable
+        std::thread([p = std::move(payload), url]() mutable
         {
             try
             {
-                cpr::Post(cpr::Url{"http://34.32.118.126:3000/match"},
+                cpr::Post(cpr::Url{url},
                           cpr::Body{p.dump()},
                           cpr::Header{{"Content-Type", "application/json"}});
             }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -18,11 +18,13 @@ Il doit contenir les champs suivants :
 {
   "SUPABASE_URL": "https://TON_PROJECT.supabase.co/rest/v1/match_sessions",
   "SUPABASE_API_KEY": "TON_API_KEY",
-  "SUPABASE_JWT": "TON_JWT"
+  "SUPABASE_JWT": "TON_JWT",
+  "BOT_ENDPOINT": "http://localhost:3000/match"
 }
 ```
 
-Lors du chargement, le plugin lit ce fichier et utilise les valeurs pour contacter Supabase.
+Lors du chargement, le plugin lit ce fichier et utilise les valeurs pour contacter Supabase
+et déterminer l'URL d'envoi des résultats au bot Discord.
 
 Le cvar `mm_player_id` doit également être configuré avec l'identifiant du joueur. Cela peut se faire via la console BakkesMod :
 
@@ -41,7 +43,8 @@ affiché dans la console BakkesMod avec le nom du joueur et le temps de jeu.
 
 Le plugin récupère les sessions de match depuis la table `match_sessions` de Supabase
 (`player_id`, `rl_name`, `rl_password`), puis envoie les informations de fin de match au bot
-Discord via une requête HTTP POST vers `http://34.32.118.126:3000`.
+Discord via une requête HTTP POST vers l'URL définie par `BOT_ENDPOINT`
+(par défaut `http://localhost:3000/match`).
 Il transmet notamment :
 
 - le score global des équipes ;

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -1,5 +1,6 @@
 {
   "SUPABASE_URL": "https://TON_PROJECT.supabase.co/rest/v1/match_sessions",
   "SUPABASE_API_KEY": "TON_API_KEY",
-  "SUPABASE_JWT": "TON_JWT"
+  "SUPABASE_JWT": "TON_JWT",
+  "BOT_ENDPOINT": "http://localhost:3000/match"
 }


### PR DESCRIPTION
## Résumé
- rend configurable l'URL utilisée par le plugin pour poster les résultats de match
- documente le nouveau champ `BOT_ENDPOINT`

## Tests
- `npm test` (échoue: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688ef73fadb0832cb67e5e93588c632a