### PR TITLE
feat: log bot endpoint in config

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -328,6 +328,7 @@ void MatchmakingPlugin::LoadConfig()
     if (jwtExpiry == 0)
         Log("[Config] Date d'expiration du JWT introuvable");
     botEndpoint = cfg.value("BOT_ENDPOINT", "http://localhost:3000/match");
+    Log("[Config] BOT_ENDPOINT=" + botEndpoint);
 }
 
 void MatchmakingPlugin::PollSupabase()


### PR DESCRIPTION
## Summary
- log configured bot endpoint each time the plugin loads configuration

## Testing
- `g++ -c plugin/MatchmakingPlugin.cpp -o /tmp/MatchmakingPlugin.o` *(fails: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688efec272bc832cb329c8535fe1d1aa