### PR TITLE
Log response of stats post

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -739,13 +739,24 @@ void MatchmakingPlugin::OnGameEnd()
         {
             try
             {
-                cpr::Post(cpr::Url{url},
-                          cpr::Body{p.dump()},
-                          cpr::Header{{"Content-Type", "application/json"}});
+                auto res = cpr::Post(cpr::Url{url},
+                                     cpr::Body{p.dump()},
+                                     cpr::Header{{"Content-Type", "application/json"}});
+
+                if (res.error.code != cpr::ErrorCode::OK)
+                    Log(std::string("[Stats] Erreur reseau : ") + res.error.message);
+                else if (res.status_code >= 200 && res.status_code < 300)
+                    Log("[Stats] Envoi reussi");
+                else
+                    Log("[Stats] Erreur HTTP " + std::to_string(res.status_code) + ": " + res.text);
+            }
+            catch (const std::exception& e)
+            {
+                Log(std::string("[Stats] Exception lors de l'envoi : ") + e.what());
             }
             catch (...)
             {
-                // Ignore network errors
+                Log("[Stats] Exception inconnue lors de l'envoi");
             }
         }).detach();
     }, 1.5f);


### PR DESCRIPTION
## Summary
- journalise en détail l'envoi des statistiques en stockant la réponse HTTP
- enregistre les erreurs réseau, les codes HTTP non OK et les exceptions lors de la requête

## Testing
- `g++ -fsyntax-only plugin/MatchmakingPlugin.cpp` *(échec : bakkesmod/plugin/bakkesmodplugin.h manquant)*

------
https://chatgpt.com/codex/tasks/task_e_688efebd6e24832c8f4b53eaec2af96a