### PR TITLE
Fix log capture in stats thread

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -734,9 +734,9 @@ void MatchmakingPlugin::OnGameEnd()
     if (debugEnabled)
         Log("[DEBUG] Envoi des stats : " + std::to_string(players.size()) + " joueurs");
 
-    gameWrapper->SetTimeout([payload = std::move(payload), url = botEndpoint](GameWrapper* /*gw*/) mutable
+    gameWrapper->SetTimeout([this, payload = std::move(payload), url = botEndpoint](GameWrapper* /*gw*/) mutable
     {
-        std::thread([p = std::move(payload), url]() mutable
+        std::thread([this, p = std::move(payload), url]() mutable
         {
             try
             {


### PR DESCRIPTION
## Summary
- capture `this` in lambda when sending match stats

## Testing
- `bash build_plugin.bat` *(fails: command not found / unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688f0020f584832cb5dcf98f1d8c8bf2