### PR TITLE
Fix outdated BakkesMod event names

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -436,11 +436,11 @@ void MatchmakingPlugin::RefreshJwt()
 void MatchmakingPlugin::HookEvents()
 {
     gameWrapper->HookEventWithCallerPost<ServerWrapper>(
-        "Function TAGame.GameEvent_Soccar_TA.OnGameStarted",
+        "Function TAGame.GameEvent_Soccar_TA.EventGameStarted",
         std::bind(&MatchmakingPlugin::OnMatchStart, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     gameWrapper->HookEventPost(
-        "Function TAGame.GameEvent_Soccar_TA.OnGameEnded",
+        "Function TAGame.GameEvent_Soccar_TA.EventGameEnded",
         std::bind(&MatchmakingPlugin::OnGameEnd, this));
 
     gameWrapper->HookEventWithCallerPost<CarWrapper>(
@@ -448,17 +448,17 @@ void MatchmakingPlugin::HookEvents()
         std::bind(&MatchmakingPlugin::OnHitBall, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     gameWrapper->HookEventWithCallerPost<CarWrapper>(
-        "Function TAGame.Car_TA.OnDemolished",
+        "Function TAGame.Car_TA.EventDemolished",
         std::bind(&MatchmakingPlugin::OnCarDemolish, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
     gameWrapper->HookEventWithCallerPost<CarWrapper>(
-        "Function TAGame.CarComponent_Boost_TA.OnBoostCollected",
+        "Function TAGame.CarComponent_Boost_TA.EventBoostCollected",
         std::bind(&MatchmakingPlugin::OnBoostCollected, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
     gameWrapper->HookEventPost(
-        "Function TAGame.GameEvent_Soccar_TA.OnGoalScored",
+        "Function TAGame.GameEvent_Soccar_TA.EventGoalScored",
         std::bind(&MatchmakingPlugin::OnGoalScored, this, std::placeholders::_1));
     // On gère les démolitions directement dans OnCarDemolish,
     // cette écoute n'est plus nécessaire.


### PR DESCRIPTION
## Summary
- Update MatchmakingPlugin event hooks to use current Rocket League event names

## Testing
- `g++ -c plugin/MatchmakingPlugin.cpp` *(fails: bakkesmod headers missing)*
- `cd bot && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f032b3430832ca7950a2b15855745