### PR TITLE
Corrige l'initialisation de CarWrapper sans paramètre

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -461,7 +461,8 @@ void MatchmakingPlugin::HookEvents()
     gameWrapper->HookEventWithCallerPost<BoostPickupWrapper>(
         "Function TAGame.VehiclePickup_Boost_TA.Pickup",
         [this](BoostPickupWrapper pickup, void* params, std::string eventName) {
-            CarWrapper car = params ? CarWrapper(*reinterpret_cast<uintptr_t*>(params)) : CarWrapper(nullptr);
+            // Si aucun paramètre n'est fourni, on construit un CarWrapper invalide
+            CarWrapper car = params ? CarWrapper(*reinterpret_cast<uintptr_t*>(params)) : CarWrapper(0);
             OnBoostCollected(car, params, eventName);
         });
     Log("[HOOK] BoostPickup OK");


### PR DESCRIPTION
## Résumé
- évite la construction de `CarWrapper` avec `nullptr` lors de la collecte de boost
- documente la création d'un `CarWrapper` invalide si aucun paramètre n'est fourni

## Test
- `g++ -std=c++17 plugin/MatchmakingPlugin.cpp -o /tmp/plugin.out` *(échoue: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f13e302b4832cbd1f3f42bf6a674d