### PR TITLE
Fix boost pickup hook to avoid unresolved symbol

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -458,9 +458,9 @@ void MatchmakingPlugin::HookEvents()
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     Log("[HOOK] EventDemolished OK");
 
-    gameWrapper->HookEventWithCallerPost<BoostPickupWrapper>(
+    gameWrapper->HookEventWithCallerPost<ActorWrapper>(
         "Function TAGame.VehiclePickup_Boost_TA.Pickup",
-        [this](BoostPickupWrapper pickup, void* params, std::string eventName) {
+        [this](ActorWrapper /*pickup*/, void* params, std::string eventName) {
             // Si aucun paramètre n'est fourni, on construit un CarWrapper invalide
             CarWrapper car = params ? CarWrapper(*reinterpret_cast<uintptr_t*>(params)) : CarWrapper(0);
             OnBoostCollected(car, params, eventName);


### PR DESCRIPTION
## Summary
- hook boost pickup using `ActorWrapper` instead of `BoostPickupWrapper` to remove unresolved external reference

## Testing
- `bash build_plugin.bat` *(fails: @echo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f14b64320832ca87b9b590d33006b