### PR TITLE
Fix conversion nom joueur

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -262,7 +262,7 @@ void MatchmakingPlugin::onLoad()
             }
         });
 
-    std::string playerName = gameWrapper->GetPlayerName();
+    std::string playerName = gameWrapper->GetPlayerName().ToString();
     if (!playerName.empty())
         cvarManager->getCvar("mm_player_id").setValue(playerName);
     else


### PR DESCRIPTION
## Résumé
- Corrige la récupération du nom du joueur dans le plugin en convertissant correctement le type UnrealStringWrapper en `std::string`.

## Test
- `g++ -std=c++17 plugin/MatchmakingPlugin.cpp -c` *(échoue : bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f25fd2a3c832c8f2d0246f2b6cce6