### PR TITLE
Respect du type de file d'attente Supabase pour les matchs privés

### DIFF
--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -396,24 +396,43 @@ void MatchmakingPlugin::PollSupabase()
             auto instr = arr.at(0);
             std::string name = instr.value("rl_name", "");
             std::string password = instr.value("rl_password", "");
+            std::string queueType = instr.value("queue_type", "");
+            int playersPerTeam = 0;
+            if (queueType == "1v1")
+                playersPerTeam = 1;
+            else if (queueType == "2v2")
+                playersPerTeam = 2;
+            else if (queueType == "3v3")
+                playersPerTeam = 3;
             if (name.empty())
             {
                 Log("[Supabase] Champ rl_name absent, aucune création de partie");
                 return;
             }
+            if (playersPerTeam == 0)
+            {
+                Log("[Supabase] queue_type invalide ou absent");
+                return;
+            }
             lastSupabaseName = name;
             lastSupabasePassword = password;
             Log("[Supabase] rl_name=" + name + ", rl_password=" + password);
-            gameWrapper->Execute([this, name, password](GameWrapper* gw) {
+            gameWrapper->Execute([this, name, password, playersPerTeam, queueType](GameWrapper* gw) {
                 auto mm = gw->GetMatchmakingWrapper();
                 if (mm)
                 {
                     CustomMatchSettings settings{};
                     settings.ServerName = name;
                     settings.Password = password;
-                    settings.MapName = "Stadium_P";
+                    settings.MapName = "DFHStadium_P";
+                    settings.GameMode = "Soccar";
+                    settings.bIsPrivateMatch = true;
+                    settings.bShouldUseBots = false;
+                    settings.bLockTeams = true;
+                    settings.NumPlayersPerTeam = playersPerTeam;
                     mm.CreatePrivateMatch(Region::EU, static_cast<int>(PlaylistIds::PrivateMatch), settings);
                     gw->Toast("Matchmaking", "\xF0\x9F\x8E\xAE Partie créée automatiquement", "default", 3.0f);
+                    Log("[Supabase] File d'attente détectée : " + queueType);
                 }
             });
 


### PR DESCRIPTION
## Résumé
- Lecture du champ `queue_type` depuis Supabase et validation des valeurs possibles
- Création de match privé configuré (carte DFHStadium_P, Soccar, Europe, pas de bots, équipes verrouillées)
- Paramétrage dynamique du nombre de joueurs par équipe et journalisation du type de file d'attente

## Tests
- `g++ -c plugin/MatchmakingPlugin.cpp` *(échoue: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f2dec0088832c96a908ca1071db38