### PR TITLE
Ajout du type de file dans les credentials de match

### DIFF
--- a/bot/advancedMatchmaking.js
+++ b/bot/advancedMatchmaking.js
@@ -145,6 +145,7 @@ export function setupAdvancedMatchmaking(client) {
       players: players.map(p => p.id),
       textId: text.id,
       voiceId: voice.id,
+      queueType: info.type,
       candidates: is1v1 ? new Set(players.map(p => p.id)) : new Set(),
       hostId: null,
       teamVoiceIds: [],
@@ -271,11 +272,15 @@ export function setupAdvancedMatchmaking(client) {
         if (playerId) {
           const encodedId = encodeURIComponent(playerId);
           const creds = await sbRequest('GET', 'match_credentials', { query: `player_id=eq.${encodedId}` }).catch(() => []);
-          if (creds.length) {
-            await sbRequest('PATCH', `match_credentials?player_id=eq.${encodedId}`, { body: { rl_name: name, rl_password: pwd } }).catch(() => {});
-          } else {
-            await sbRequest('POST', 'match_credentials', { body: { player_id: playerId, rl_name: name, rl_password: pwd } }).catch(() => {});
-          }
+            if (creds.length) {
+              await sbRequest('PATCH', `match_credentials?player_id=eq.${encodedId}`, {
+                body: { rl_name: name, rl_password: pwd, queue_type: match.queueType }
+              }).catch(() => {});
+            } else {
+              await sbRequest('POST', 'match_credentials', {
+                body: { player_id: playerId, rl_name: name, rl_password: pwd, queue_type: match.queueType }
+              }).catch(() => {});
+            }
         }
       } catch (err) {
         console.error('Erreur maj credentials', err);


### PR DESCRIPTION
## Résumé
- stocke le type de file `queueType` pour chaque match actif
- enregistre `queue_type` dans Supabase lors de la création des identifiants de match

## Tests
- `npm test` (script manquant)

------
https://chatgpt.com/codex/tasks/task_e_688f30a29650832c8150ffb023b34912