### PR TITLE
Revenir au comportement simple de creation de partie

### DIFF
--- a/bot/advancedMatchmaking.js
+++ b/bot/advancedMatchmaking.js
@@ -272,15 +272,15 @@ export function setupAdvancedMatchmaking(client) {
         if (playerId) {
           const encodedId = encodeURIComponent(playerId);
           const creds = await sbRequest('GET', 'match_credentials', { query: `player_id=eq.${encodedId}` }).catch(() => []);
-            if (creds.length) {
-              await sbRequest('PATCH', `match_credentials?player_id=eq.${encodedId}`, {
-                body: { rl_name: name, rl_password: pwd, queue_type: match.queueType }
-              }).catch(() => {});
-            } else {
-              await sbRequest('POST', 'match_credentials', {
-                body: { player_id: playerId, rl_name: name, rl_password: pwd, queue_type: match.queueType }
-              }).catch(() => {});
-            }
+          if (creds.length) {
+            await sbRequest('PATCH', `match_credentials?player_id=eq.${encodedId}`, {
+              body: { rl_name: name, rl_password: pwd }
+            }).catch(() => {});
+          } else {
+            await sbRequest('POST', 'match_credentials', {
+              body: { player_id: playerId, rl_name: name, rl_password: pwd }
+            }).catch(() => {});
+          }
         }
       } catch (err) {
         console.error('Erreur maj credentials', err);

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -396,45 +396,25 @@ void MatchmakingPlugin::PollSupabase()
             auto instr = arr.at(0);
             std::string name = instr.value("rl_name", "");
             std::string password = instr.value("rl_password", "");
-            std::string queueType = instr.value("queue_type", "");
-            int playersPerTeam = 0;
-            if (queueType == "1v1")
-                playersPerTeam = 1;
-            else if (queueType == "2v2")
-                playersPerTeam = 2;
-            else if (queueType == "3v3")
-                playersPerTeam = 3;
             if (name.empty())
             {
                 Log("[Supabase] Champ rl_name absent, aucune création de partie");
                 return;
             }
-            if (playersPerTeam == 0)
-            {
-                Log("[Supabase] queue_type invalide ou absent");
-                return;
-            }
             lastSupabaseName = name;
             lastSupabasePassword = password;
             Log("[Supabase] rl_name=" + name + ", rl_password=" + password);
-            gameWrapper->Execute([this, name, password, playersPerTeam, queueType](GameWrapper* gw) {
+            gameWrapper->Execute([this, name, password](GameWrapper* gw) {
                 auto mm = gw->GetMatchmakingWrapper();
                 if (mm)
                 {
                     CustomMatchSettings settings{};
                     settings.ServerName = name;
                     settings.Password = password;
-                    settings.MapName = "DFHStadium_P";
-                    // 0 corresponds to the standard "Soccar" game mode
-                    settings.GameMode = 0;
-                    // New SDK expects the total number of players rather than per team
-                    settings.MaxPlayerCount = playersPerTeam * 2;
-                    // Restrict the lobby to party members only and disable club server behaviour
-                    settings.bPartyMembersOnly = true;
-                    settings.bClubServer = false;
+                    settings.MapName = "Stadium_P";
+                    settings.MaxPlayerCount = 2; // 1v1
                     mm.CreatePrivateMatch(Region::EU, static_cast<int>(PlaylistIds::PrivateMatch), settings);
                     gw->Toast("Matchmaking", "\xF0\x9F\x8E\xAE Partie créée automatiquement", "default", 3.0f);
-                    Log("[Supabase] File d'attente détectée : " + queueType);
                 }
             });
 


### PR DESCRIPTION
## Résumé
- Supprimer la gestion `queue_type` et les paramètres avancés lors de la création de la partie privée
- Nettoyer le bot afin qu'il n'envoie plus `queue_type` dans les `match_credentials`
- Forcer la création de parties privées en 1v1

## Tests
- `npm test --prefix bot` *(échoue : Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688fa63ee714832caaeb91d66d3e39b3