### PR TITLE
Revenir au comportement simple de creation de partie

### DIFF
--- a/bot/advancedMatchmaking.js
+++ b/bot/advancedMatchmaking.js
@@ -272,15 +272,15 @@ export function setupAdvancedMatchmaking(client) {
         if (playerId) {
           const encodedId = encodeURIComponent(playerId);
           const creds = await sbRequest('GET', 'match_credentials', { query: `player_id=eq.${encodedId}` }).catch(() => []);
-            if (creds.length) {
-              await sbRequest('PATCH', `match_credentials?player_id=eq.${encodedId}`, {
-                body: { rl_name: name, rl_password: pwd, queue_type: match.queueType }
-              }).catch(() => {});
-            } else {
-              await sbRequest('POST', 'match_credentials', {
-                body: { player_id: playerId, rl_name: name, rl_password: pwd, queue_type: match.queueType }
-              }).catch(() => {});
-            }
+          if (creds.length) {
+            await sbRequest('PATCH', `match_credentials?player_id=eq.${encodedId}`, {
+              body: { rl_name: name, rl_password: pwd }
+            }).catch(() => {});
+          } else {
+            await sbRequest('POST', 'match_credentials', {
+              body: { player_id: playerId, rl_name: name, rl_password: pwd }
+            }).catch(() => {});
+          }
         }
       } catch (err) {
         console.error('Erreur maj credentials', err);

--- a/plugin/MatchmakingPlugin.cpp
+++ b/plugin/MatchmakingPlugin.cpp
@@ -396,45 +396,25 @@ void MatchmakingPlugin::PollSupabase()
             auto instr = arr.at(0);
             std::string name = instr.value("rl_name", "");
             std::string password = instr.value("rl_password", "");
-            std::string queueType = instr.value("queue_type", "");
-            int playersPerTeam = 0;
-            if (queueType == "1v1")
-                playersPerTeam = 1;
-            else if (queueType == "2v2")
-                playersPerTeam = 2;
-            else if (queueType == "3v3")
-                playersPerTeam = 3;
             if (name.empty())
             {
                 Log("[Supabase] Champ rl_name absent, aucune création de partie");
                 return;
             }
-            if (playersPerTeam == 0)
-            {
-                Log("[Supabase] queue_type invalide ou absent");
-                return;
-            }
             lastSupabaseName = name;
             lastSupabasePassword = password;
             Log("[Supabase] rl_name=" + name + ", rl_password=" + password);
-            gameWrapper->Execute([this, name, password, playersPerTeam, queueType](GameWrapper* gw) {
+            gameWrapper->Execute([this, name, password](GameWrapper* gw) {
                 auto mm = gw->GetMatchmakingWrapper();
                 if (mm)
                 {
                     CustomMatchSettings settings{};
                     settings.ServerName = name;
                     settings.Password = password;
-                    settings.MapName = "DFHStadium_P";
-                    // 0 corresponds to the standard "Soccar" game mode
-                    settings.GameMode = 0;
-                    // New SDK expects the total number of players rather than per team
-                    settings.MaxPlayerCount = playersPerTeam * 2;
-                    // Restrict the lobby to party members only and disable club server behaviour
-                    settings.bPartyMembersOnly = true;
-                    settings.bClubServer = false;
+                    settings.MapName = "Stadium_P";
+                    settings.MaxPlayerCount = 2; // 1v1
                     mm.CreatePrivateMatch(Region::EU, static_cast<int>(PlaylistIds::PrivateMatch), settings);
                     gw->Toast("Matchmaking", "\xF0\x9F\x8E\xAE Partie créée automatiquement", "default", 3.0f);
-                    Log("[Supabase] File d'attente détectée : " + queueType);
                 }
             });
 
@@ -660,6 +640,21 @@ void MatchmakingPlugin::OnGameEnd()
     try
     {
         Log("[OnGameEnd] Debut du traitement");
+
+        // Nettoie les cvars Rocket League afin d'eviter toute reutilisation accidentelle
+        auto clearCvar = [this](const std::string& name)
+        {
+            CVarWrapper cv = cvarManager->getCvar(name);
+            if (!cv.IsNull())
+                cv.setValue("");
+        };
+        clearCvar("rl_name");
+        clearCvar("rl_password");
+        clearCvar("queue_type");
+
+        lastSupabaseName.clear();
+        lastSupabasePassword.clear();
+
         ServerWrapper sw = gameWrapper->GetCurrentGameState();
         if (!sw)
             return;
@@ -692,7 +687,7 @@ void MatchmakingPlugin::OnGameEnd()
                 cpr::Patch(
                     cpr::Url{supabaseUrl},
                     cpr::Parameters{{"player_id", "eq." + playerId}},
-                    cpr::Body{"{\"rl_name\":null,\"rl_password\":null}"},
+                    cpr::Body{"{\"rl_name\":null,\"rl_password\":null,\"queue_type\":null}"},
                     headers);
             }
             catch (const std::exception& e)


### PR DESCRIPTION
## Résumé
- Nettoyer les cvars Rocket League (`rl_name`, `rl_password`, `queue_type`) une fois la partie terminée
- Envoyer à Supabase un nettoyage complet incluant désormais `queue_type`

## Tests
- `npm test --prefix bot` *(échoue : Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688fa63ee714832caaeb91d66d3e39b3