### PR TITLE
Fix parent team parent id type

### DIFF
--- a/bot/team.js
+++ b/bot/team.js
@@ -860,12 +860,13 @@ export function setupTeam(client) {
             await interaction.reply({ content: 'Capitaine uniquement.', ephemeral: true });
             return;
           }
-          const existing = await sbRequest('GET', 'teams', { query: `parent_team_id=eq.${parent.id}` });
+          const parentId = Number(parent.id);
+          const existing = await sbRequest('GET', 'teams', { query: `parent_team_id=eq.${parentId}` });
           if (existing.length) {
             await interaction.reply({ content: 'Roster secondaire déjà existant.', ephemeral: true });
             return;
           }
-          const roster = await sbRequest('POST', 'teams', { body: { name, elo: 1000, captain_id: interaction.user.id, parent_team_id: parent.id } });
+          const roster = await sbRequest('POST', 'teams', { body: { name, elo: 1000, captain_id: interaction.user.id, parent_team_id: parentId } });
           await sbRequest('POST', 'team_members', { body: { user_id: interaction.user.id, team_id: roster[0].id } }).catch(() => {});
           await createRosterResources(interaction, name);
           await interaction.reply({ content: `Roster **${name}** créé.`, ephemeral: true });

--- a/supabase/migrations/20240505120000_alter_teams_parent_team_id.sql
+++ b/supabase/migrations/20240505120000_alter_teams_parent_team_id.sql
@@ -1,0 +1,11 @@
+ALTER TABLE teams
+  ALTER COLUMN parent_team_id TYPE bigint USING parent_team_id::bigint;
+
+ALTER TABLE teams
+  DROP CONSTRAINT IF EXISTS teams_parent_team_id_fkey;
+
+ALTER TABLE teams
+  ADD CONSTRAINT teams_parent_team_id_fkey
+  FOREIGN KEY (parent_team_id)
+  REFERENCES teams (id)
+  ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- align `teams.parent_team_id` with `id` and recreate foreign key
- send numeric `parent_team_id` when creating secondary roster

## Testing
- `sudo -u postgres psql -c "INSERT INTO teams (name, parent_team_id) VALUES ('Child', 1) RETURNING id, parent_team_id;"`
- `sudo -u postgres psql -c "INSERT INTO teams (name, parent_team_id) VALUES ('Orphan', 999);"` *(fails: foreign key constraint)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689070ea5d70832c8a13e346027105a9