### PR TITLE
Gère la prolongation dans la durée du match

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -158,9 +158,13 @@ app.post('/match', async (req, res) => {
     scorers = [],
     mvp = '',
     players: rawPlayers = [],
-    duration = '5:00',
+    overtime = 0,
     map = 'Inconnu'
   } = req.body;
+  const totalSeconds = 300 + Number(overtime || 0);
+  const duration = `${String(Math.floor(totalSeconds / 60)).padStart(2, '0')}:${String(
+    Math.floor(totalSeconds % 60)
+  ).padStart(2, '0')}`;
   const players = rawPlayers.map(p => ({
     ...p,
     rotationQuality: getRotationQuality(p)

--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -873,6 +873,9 @@ void AuusaConnectPlugin::OnGameEnd()
         }
     }
 
+    float matchTime = sw.GetSecondsElapsed();
+    int overtime = std::max(0, static_cast<int>(std::round(matchTime - 300.f)));
+
     json payload = {
         {"scoreBlue", scoreBlue},
         {"scoreOrange", scoreOrange},
@@ -880,7 +883,8 @@ void AuusaConnectPlugin::OnGameEnd()
         {"teamOrange", orangeName},
         {"scorers", scorers},
         {"mvp", mvp},
-        {"players", players}
+        {"players", players},
+        {"overtime", overtime}
     };
 
     if (debugEnabled)


### PR DESCRIPTION
## Résumé
- Calcule la durée totale du match en additionnant prolongation et temps réglementaire
- Envoie la durée de prolongation depuis le plugin pour un affichage correct

## Tests
- `npm test` (échec : Missing script: "test")
- `node --check index.js`
- `g++ -std=c++17 -c plugin/AuusaConnectPlugin.cpp` (échec : bakkesmod/plugin/bakkesmodplugin.h introuvable)


------
https://chatgpt.com/codex/tasks/task_e_68929ba062b0832c93a43d9b36074d8a