### PR TITLE
Affichage du nom de la carte

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -48,6 +48,25 @@ const client = new Client({
 const matchData = new Map();
 const recentMatches = new Set();
 
+const mapTranslations = {
+  DFHStadium: 'Stade DFH',
+  Mannfield: 'Mannfield',
+  ChampionsField: 'Stade des Champions',
+  UrbanCentral: 'Centre urbain',
+  BeckwithPark: 'Parc Beckwith',
+  ForbiddenTemple: 'Temple interdit',
+  Aquadome: 'Aquadome',
+  UtopiaColiseum: 'Colisée Utopia',
+  NeoTokyo: 'Neo Tokyo',
+  Farmstead: 'Ferme',
+  RivalsArena: 'Arène des Rivaux'
+};
+
+function translateMap(name) {
+  if (!name) return 'Inconnu';
+  return mapTranslations[name] || name;
+}
+
 function getMatchSignature(payload) {
   const players = payload.players.map(p => p.name).sort().join('|');
   const totalGoals = payload.scoreBlue + payload.scoreOrange;
@@ -159,8 +178,9 @@ app.post('/match', async (req, res) => {
     mvp = '',
     players: rawPlayers = [],
     duration = '5:00',
-    map = 'Inconnu'
+    map: rawMap = ''
   } = req.body;
+  const map = translateMap(rawMap);
   const players = rawPlayers.map(p => ({
     ...p,
     rotationQuality: getRotationQuality(p)

--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -800,6 +800,7 @@ void AuusaConnectPlugin::OnGameEnd()
 
     std::string blueName = blueTeam.GetTeamName().ToString();
     std::string orangeName = orangeTeam.GetTeamName().ToString();
+    std::string mapName = sw.GetMapName().ToString();
 
     ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
     json players = json::array();
@@ -878,6 +879,7 @@ void AuusaConnectPlugin::OnGameEnd()
         {"scoreOrange", scoreOrange},
         {"teamBlue", blueName},
         {"teamOrange", orangeName},
+        {"map", mapName},
         {"scorers", scorers},
         {"mvp", mvp},
         {"players", players}


### PR DESCRIPTION
## Résumé
- Ajout de l’envoi du nom de la carte depuis le plugin via `ServerWrapper::GetMapName`.
- Introduction d’un dictionnaire de traduction des cartes et conversion côté bot.
- Affichage des noms de carte traduits dans les messages de fin de match.

## Tests
- `npm test` *(échoue : Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68929c419448832cbeb3bc44761fc436