### PR TITLE
Corriger compilation: supprimer GetMapName et macros

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -1,3 +1,4 @@
+#define NOMINMAX
 #include "bakkesmod/plugin/bakkesmodplugin.h"
 #include "bakkesmod/wrappers/WrapperStructs.h"
 #include "bakkesmod/wrappers/MatchmakingWrapper.h"
@@ -15,6 +16,9 @@
 #include <memory>
 #include <exception>
 #include <ctime>
+
+#undef min
+#undef max
 
 using json = nlohmann::json;
 
@@ -802,7 +806,7 @@ void AuusaConnectPlugin::OnGameEnd()
 
     std::string blueName = blueTeam.GetTeamName().ToString();
     std::string orangeName = orangeTeam.GetTeamName().ToString();
-    std::string mapName = sw.GetMapName().ToString();
+    std::string mapName = gameWrapper->GetCurrentMap();
 
     ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
     json players = json::array();


### PR DESCRIPTION
## Résumé
- remplacer `ServerWrapper::GetMapName` par `GameWrapper::GetCurrentMap`
- éviter les macros `min/max` de Windows en définissant `NOMINMAX`

## Test
- `g++ -std=c++17 -c plugin/AuusaConnectPlugin.cpp` *(échec : bakkesmodplugin.h introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68929f34aec0832ca2f124f2b840bf30