### PR TITLE
Prevent JSON errors when Supabase fields are null

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -439,9 +439,21 @@ void AuusaConnectPlugin::PollSupabase()
                 return;
             }
             auto instr = arr.at(0);
-            std::string name = instr.value("rl_name", "");
-            std::string password = instr.value("rl_password", "");
-            std::string queueType = instr.value("queue_type", "");
+            std::string name;
+            if (instr.contains("rl_name") && instr["rl_name"].is_string())
+                name = instr["rl_name"].get<std::string>();
+            else
+                name = "";
+            std::string password;
+            if (instr.contains("rl_password") && instr["rl_password"].is_string())
+                password = instr["rl_password"].get<std::string>();
+            else
+                password = "";
+            std::string queueType;
+            if (instr.contains("queue_type") && instr["queue_type"].is_string())
+                queueType = instr["queue_type"].get<std::string>();
+            else
+                queueType = "";
             if (name.empty())
             {
                 Log("[Supabase] Champ rl_name absent, aucune action");
@@ -782,7 +794,7 @@ void AuusaConnectPlugin::OnGameEnd()
                 auto res = cpr::Patch(
                     cpr::Url{supabaseUrl},
                     cpr::Parameters{{"player_id", "eq." + playerId}},
-                    cpr::Body{"{\"rl_name\":\"\",\"rl_password\":\"\",\"queue_type\":null}"},
+                    cpr::Body{"{\"rl_name\":\"\",\"rl_password\":\"\",\"queue_type\":\"\"}"},
                     headers);
                 if (res.status_code >= 400)
                     Log("[Supabase] Nettoyage echoue : HTTP " + std::to_string(res.status_code) + " - " + res.text);


### PR DESCRIPTION
## Summary
- Avoid exceptions when `rl_name`, `rl_password` or `queue_type` are `null` by checking presence and type before reading
- Reset Supabase sessions with empty string `queue_type` instead of `null`

## Testing
- `cd bot && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68930b430078832cb0969acb7eb9e9b3