### PR TITLE
Sécurisation de l'endpoint de match

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,3 +1,4 @@
 DISCORD_TOKEN=VotreTokenIci
 SUPABASE_URL=https://votre-instance.supabase.co
 SUPABASE_KEY=cle-service
+API_SECRET=VotreSecretAPI

--- a/bot/README.md
+++ b/bot/README.md
@@ -24,6 +24,7 @@ Les variables nécessaires sont :
 - `DISCORD_TOKEN` : token de votre bot Discord
 - `SUPABASE_URL` : URL de l'instance Supabase
 - `SUPABASE_KEY` : clé de service pour effectuer les requêtes REST
+- `API_SECRET` : clé partagée avec le plugin pour sécuriser l'endpoint `/match`
 
 ```bash
 node index.js

--- a/bot/index.js
+++ b/bot/index.js
@@ -25,6 +25,8 @@ import { setupAdvancedMatchmaking, handleMatchResult } from "./advancedMatchmaki
 const app = express();
 app.use(bodyParser.json());
 
+const API_SECRET = process.env.API_SECRET;
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CHANNEL_FILE = path.join(__dirname, 'channel.json');
 let channelId = '';
@@ -242,6 +244,10 @@ async function runChannelSetup(interaction) {
 }
 
 app.post('/match', async (req, res) => {
+  const apiKey = req.get('x-api-key');
+  if (!API_SECRET || apiKey !== API_SECRET) {
+    return res.sendStatus(401);
+  }
   const signature = getMatchSignature(req.body);
   if (recentMatches.has(signature)) {
     return res.sendStatus(200);

--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -170,6 +170,7 @@ private:
     std::string lastSupabasePassword;
     bool supabaseDisabled = false;
     std::string botEndpoint = "http://localhost:3000/match";
+    std::string apiSecret;
     bool creatingMatch = false;
     bool autoJoined = false;
 };
@@ -366,6 +367,7 @@ void AuusaConnectPlugin::LoadConfig()
         Log("[Config] Date d'expiration du JWT introuvable");
     botEndpoint = cfg.value("BOT_ENDPOINT", "http://localhost:3000/match");
     Log("[Config] BOT_ENDPOINT=" + botEndpoint);
+    apiSecret = cfg.value("API_SECRET", "");
 }
 
 void AuusaConnectPlugin::PollSupabase()
@@ -904,9 +906,12 @@ void AuusaConnectPlugin::OnGameEnd()
         {
             try
             {
+                cpr::Header headers{{"Content-Type", "application/json"}};
+                if (!apiSecret.empty())
+                    headers.emplace("X-API-KEY", apiSecret);
                 auto res = cpr::Post(cpr::Url{url},
                                      cpr::Body{p.dump()},
-                                     cpr::Header{{"Content-Type", "application/json"}});
+                                     headers);
 
                 if (res.error.code != cpr::ErrorCode::OK)
                     Log(std::string("[Stats] Erreur reseau : ") + res.error.message);

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -19,7 +19,8 @@ Il doit contenir les champs suivants :
   "SUPABASE_URL": "https://TON_PROJECT.supabase.co/rest/v1/match_sessions",
   "SUPABASE_API_KEY": "TON_API_KEY",
   "SUPABASE_JWT": "TON_JWT",
-  "BOT_ENDPOINT": "http://localhost:3000/match"
+  "BOT_ENDPOINT": "http://localhost:3000/match",
+  "API_SECRET": "VOTRE_SECRET"
 }
 ```
 

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -2,5 +2,6 @@
   "SUPABASE_URL": "https://srszelabkxvdrmorfovm.supabase.co/rest/v1/match_credentials",
   "SUPABASE_API_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNyc3plbGFia3h2ZHJtb3Jmb3ZtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAwNDQxMDUsImV4cCI6MjA2NTYyMDEwNX0.ixXgOg6eznTi3YES_sYnYQFEBS17oGSpjd8qwxHEQ94",
   "SUPABASE_JWT": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNyc3plbGFia3h2ZHJtb3Jmb3ZtIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1MDA0NDEwNSwiZXhwIjoyMDY1NjIwMTA1fQ.fRm3eDVaZGsga8rBe752ukmXRnjvkFOwv46vo6fcRZY",
-  "BOT_ENDPOINT": "http://34.32.118.126:3000/match"
+  "BOT_ENDPOINT": "http://34.32.118.126:3000/match",
+  "API_SECRET": "change-me"
 }


### PR DESCRIPTION
## Résumé
- vérification de la clé secrète `API_SECRET` sur la route `/match`
- envoi de la clé via l'en-tête `X-API-KEY` depuis le plugin
- documentation et exemples mis à jour pour la clé

## Tests
- `npm test` *(échoue : Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894bd17a4f0832cac1b805456d30210