### PR TITLE
Sécurisation de l'API et externalisation des secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Chaque dossier possède un `README.md` détaillant la mise en place.
 ## Configuration sécurisée
 
 Le plugin lit les secrets (`SUPABASE_URL`, `SUPABASE_API_KEY`, `SUPABASE_JWT`,
-`BOT_ENDPOINT`) depuis des variables d'environnement ou un fichier local
+`BOT_ENDPOINT`, `API_SECRET`) depuis des variables d'environnement ou un fichier local
 `config.json` (ignoré par Git). Un modèle `config.example.json` est disponible
 dans `plugin/`. Copiez-le puis renseignez vos valeurs ou exportez les variables
 correspondantes.

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -13,8 +13,9 @@
         "discord.js": "^14.0.0",
         "dotenv": "^16.0.0",
         "express": "^4.18.0",
+        "express-rate-limit": "^7.5.1",
+        "helmet": "^7.2.0",
         "joi": "^18.0.0"
-
       }
     },
     "node_modules/@discordjs/builders": {
@@ -586,13 +587,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
-      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.0.1"
-      },
       "engines": {
         "node": ">= 16"
       },
@@ -728,12 +726,12 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -769,15 +767,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/bot/package.json
+++ b/bot/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "dependencies": {
     "body-parser": "^1.20.0",
+    "cors": "^2.8.5",
     "discord.js": "^14.0.0",
     "dotenv": "^16.0.0",
     "express": "^4.18.0",
+    "express-rate-limit": "^7.5.1",
+    "helmet": "^7.2.0",
     "joi": "^18.0.0"
   }
 }

--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -186,12 +186,8 @@ private:
     std::string lastSupabaseName;
     std::string lastSupabasePassword;
     bool supabaseDisabled = false;
-<<<<<<< HEAD
-    std::string botEndpoint = "http://localhost:3000/match";
-    std::string apiSecret;
-=======
     std::string botEndpoint = "https://localhost:3000/match";
->>>>>>> origin/main
+    std::string apiSecret;
     bool creatingMatch = false;
     bool autoJoined = false;
 };
@@ -370,9 +366,11 @@ void AuusaConnectPlugin::LoadConfig()
     supabaseApiKey = getEnv("SUPABASE_API_KEY");
     supabaseJwt = getEnv("SUPABASE_JWT");
     botEndpoint = getEnv("BOT_ENDPOINT");
+    apiSecret = getEnv("API_SECRET");
 
     std::filesystem::path path = gameWrapper->GetDataFolder() / "config.json";
-    if (supabaseUrl.empty() || supabaseApiKey.empty() || supabaseJwt.empty() || botEndpoint.empty())
+    if (supabaseUrl.empty() || supabaseApiKey.empty() || supabaseJwt.empty() ||
+        botEndpoint.empty() || apiSecret.empty())
     {
         std::ifstream file(path);
         if (!file.is_open())
@@ -392,6 +390,7 @@ void AuusaConnectPlugin::LoadConfig()
                 if (supabaseApiKey.empty()) supabaseApiKey = cfg.value("SUPABASE_API_KEY", "");
                 if (supabaseJwt.empty()) supabaseJwt = cfg.value("SUPABASE_JWT", "");
                 if (botEndpoint.empty()) botEndpoint = cfg.value("BOT_ENDPOINT", "");
+                if (apiSecret.empty()) apiSecret = cfg.value("API_SECRET", "");
             }
         }
     }
@@ -406,7 +405,8 @@ void AuusaConnectPlugin::LoadConfig()
         Log("[Config] BOT_ENDPOINT doit utiliser HTTPS");
 
     Log("[Config] BOT_ENDPOINT=" + botEndpoint);
-    apiSecret = cfg.value("API_SECRET", "");
+    if (apiSecret.empty())
+        Log("[Config] API_SECRET manquant");
 }
 
 void AuusaConnectPlugin::PollSupabase()
@@ -966,15 +966,11 @@ void AuusaConnectPlugin::OnGameEnd()
                 cpr::Header headers{{"Content-Type", "application/json"}};
                 if (!apiSecret.empty())
                     headers.emplace("X-Signature", HmacSha256(apiSecret, body));
-                auto res = cpr::Post(cpr::Url{url},
-<<<<<<< HEAD
-                                     cpr::Body{body},
-                                     headers);
-=======
-                                     cpr::Body{p.dump()},
-                                     cpr::Header{{"Content-Type", "application/json"}},
-                                     cpr::VerifySsl{true});
->>>>>>> origin/main
+                auto res = cpr::Post(
+                    cpr::Url{url},
+                    cpr::Body{body},
+                    headers,
+                    cpr::VerifySsl{true});
 
                 if (res.error.code != cpr::ErrorCode::OK)
                     Log(std::string("[Stats] Erreur reseau : ") + res.error.message);

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -13,7 +13,7 @@ Ce dossier contient le plugin Bakkesmod AuusaConnect.
 
 Copiez `config.example.json` vers un fichier `config.json` dans le dossier de données du plugin puis
 remplissez vos secrets. Vous pouvez également définir les variables d'environnement
-`SUPABASE_URL`, `SUPABASE_API_KEY`, `SUPABASE_JWT` et `BOT_ENDPOINT`.
+`SUPABASE_URL`, `SUPABASE_API_KEY`, `SUPABASE_JWT`, `BOT_ENDPOINT` et `API_SECRET`.
 
 Le fichier `config.json` étant local, il n'est pas versionné.
 
@@ -24,7 +24,8 @@ Exemple de contenu :
   "SUPABASE_URL": "https://TON_PROJECT.supabase.co/rest/v1/match_sessions",
   "SUPABASE_API_KEY": "TON_API_KEY",
   "SUPABASE_JWT": "TON_JWT",
-  "BOT_ENDPOINT": "https://localhost:3000/match"
+  "BOT_ENDPOINT": "https://localhost:3000/match",
+  "API_SECRET": "TON_API_SECRET"
 }
 ```
 

--- a/plugin/config.example.json
+++ b/plugin/config.example.json
@@ -2,5 +2,6 @@
   "SUPABASE_URL": "https://TON_PROJECT.supabase.co/rest/v1/match_sessions",
   "SUPABASE_API_KEY": "VOTRE_API_KEY",
   "SUPABASE_JWT": "VOTRE_JWT",
-  "BOT_ENDPOINT": "https://localhost:3000/match"
+  "BOT_ENDPOINT": "https://localhost:3000/match",
+  "API_SECRET": "VOTRE_API_SECRET"
 }

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -1,7 +1,0 @@
-{
-  "SUPABASE_URL": "https://srszelabkxvdrmorfovm.supabase.co/rest/v1/match_credentials",
-  "SUPABASE_API_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNyc3plbGFia3h2ZHJtb3Jmb3ZtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAwNDQxMDUsImV4cCI6MjA2NTYyMDEwNX0.ixXgOg6eznTi3YES_sYnYQFEBS17oGSpjd8qwxHEQ94",
-  "SUPABASE_JWT": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNyc3plbGFia3h2ZHJtb3Jmb3ZtIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1MDA0NDEwNSwiZXhwIjoyMDY1NjIwMTA1fQ.fRm3eDVaZGsga8rBe752ukmXRnjvkFOwv46vo6fcRZY",
-  "BOT_ENDPOINT": "http://34.32.118.126:3000/match",
-  "API_SECRET": "change-me"
-}


### PR DESCRIPTION
## Résumé
- Ajout de middlewares de sécurité (Helmet, rate limiting, CORS) et vérification HMAC avec validation Joi sur l'endpoint `/match`
- Lecture sécurisée des secrets côté plugin avec URL HTTPS par défaut et signature HMAC des requêtes
- Remplacement du fichier de configuration sensible par un exemple et documentation mise à jour

## Tests
- `npm test` *(échec : Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894bbe9d3b0832c8eb13f571a9e98a7