### PR TITLE
Simplifie la configuration du plugin

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -335,12 +335,18 @@ void AuusaConnectPlugin::LoadConfig()
             {
                 if (botEndpoint.empty()) botEndpoint = cfg.value("BOT_ENDPOINT", "");
                 if (apiSecret.empty()) apiSecret = cfg.value("API_SECRET", "");
+
+                for (auto& [key, val] : cfg.items())
+                {
+                    if (key.rfind("SUPABASE_", 0) == 0)
+                        Log("[Config] Champ " + key + " obsolète ignoré");
+                }
             }
         }
     }
 
     if (botEndpoint.empty())
-        botEndpoint = "https://localhost:3000/match";
+        botEndpoint = "https://api.auusa.fr/match";
     if (botEndpoint.rfind("https://", 0) != 0)
         Log("[Config] BOT_ENDPOINT doit utiliser HTTPS");
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,8 +21,8 @@ Exemple de contenu :
 
 ```json
 {
-  "BOT_ENDPOINT": "https://localhost:3000/match",
-  "API_SECRET": "TON_API_SECRET"
+  "BOT_ENDPOINT": "https://api.auusa.fr/match",
+  "API_SECRET": "..."
 }
 ```
 
@@ -48,7 +48,7 @@ Le plugin récupère les sessions de match via un serveur proxy sécurisé
 (`https://api.auusa.fr/player?player_id=wChrist`) qui renvoie uniquement
 `rl_name`, `rl_password` et `queue_type`, puis envoie les informations de fin de match au bot
 Discord via une requête HTTP POST vers l'URL définie par `BOT_ENDPOINT`
-(par défaut `https://localhost:3000/match`).
+(par défaut `https://api.auusa.fr/match`).
 Il transmet notamment :
 
 - le score global des équipes ;

--- a/plugin/config.example.json
+++ b/plugin/config.example.json
@@ -1,4 +1,4 @@
 {
-  "BOT_ENDPOINT": "https://localhost:3000/match",
-  "API_SECRET": "VOTRE_API_SECRET"
+  "BOT_ENDPOINT": "https://api.auusa.fr/match",
+  "API_SECRET": "..."
 }


### PR DESCRIPTION
## Résumé
- Met à jour `config.example.json` avec une configuration minimale sans champs Supabase.
- Ajuste `LoadConfig` pour ignorer les anciens champs `SUPABASE_*` et adopter l’URL par défaut `https://api.auusa.fr/match`.
- Documente la nouvelle configuration dans `plugin/README.md`.

## Tests
- `npm test` *(échoue : Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894f9c545c4832cb6cd860cfac82713