### PR TITLE
feat: activer HTTPS et clarifier BOT_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ ou un fichier local `config.json` (ignoré par Git). Un modèle `config.example.
 disponible dans `plugin/`. Copiez-le puis renseignez vos valeurs ou exportez les variables
 correspondantes.
 
+Pour le développement local, générez un certificat auto-signé puis lancez le bot en HTTPS :
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
+SSL_KEY_PATH=./key.pem SSL_CERT_PATH=./cert.pem node bot/index.js
+```
+
+Dans ce cas, configurez le plugin avec `BOT_ENDPOINT=https://localhost:3000/match`.
+En production, utilisez un certificat Let's Encrypt ou un reverse proxy (Nginx, Caddy)
+et adaptez `BOT_ENDPOINT` vers l'URL publique, par exemple
+`https://api.exemple.fr/match`.
+
 ## Base de données Supabase
 
 Les tables suivantes doivent être créées dans votre projet Supabase :

--- a/bot/README.md
+++ b/bot/README.md
@@ -31,6 +31,18 @@ Les variables nécessaires sont :
 node index.js
 ```
 
+### HTTPS
+
+Si `SSL_KEY_PATH` et `SSL_CERT_PATH` sont définis, le bot démarre en HTTPS.
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
+SSL_KEY_PATH=./key.pem SSL_CERT_PATH=./cert.pem node index.js
+```
+
+En production, utilisez un certificat Let's Encrypt ou placez le bot derrière
+un reverse proxy (Nginx, Caddy).
+
 Au premier lancement, le bot enregistre automatiquement la commande slash
 `/setup`. Celle-ci comporte plusieurs sous-commandes :
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'url';
 import express from 'express';
 import bodyParser from 'body-parser';
 import crypto from 'crypto';
+import https from 'https';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import cors from 'cors';
@@ -784,7 +785,16 @@ client.on('interactionCreate', async interaction => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`API en écoute sur le port ${PORT}`));
+const { SSL_KEY_PATH, SSL_CERT_PATH } = process.env;
+if (SSL_KEY_PATH && SSL_CERT_PATH) {
+  const key = fs.readFileSync(SSL_KEY_PATH);
+  const cert = fs.readFileSync(SSL_CERT_PATH);
+  https.createServer({ key, cert }, app).listen(PORT, () =>
+    console.log(`API HTTPS en écoute sur le port ${PORT}`)
+  );
+} else {
+  app.listen(PORT, () => console.log(`API HTTP en écoute sur le port ${PORT}`));
+}
 
 client.on('error', console.error);
 process.on('unhandledRejection', err => console.error('Unhandled promise rejection:', err));

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -27,6 +27,9 @@ Exemple de contenu :
 ```
 
 `BOT_ENDPOINT` doit obligatoirement utiliser `https://`.
+En développement, pointez vers `https://localhost:3000/match` avec le certificat auto-signé
+du bot. En production, renseignez l'URL publique de votre API sécurisée (Let's Encrypt ou
+reverse proxy).
 Lors du chargement, le plugin lit d'abord les variables d'environnement puis, si nécessaire,
 le fichier pour déterminer l'URL d'envoi des résultats au bot Discord.
 


### PR DESCRIPTION
## Summary
- ajout du support HTTPS via certificat fourni par variables d'environnement
- documenter l'utilisation de BOT_ENDPOINT selon l'environnement
- indiquer comment générer un certificat auto-signé pour le développement

## Testing
- `node --check bot/index.js`
- `cd bot && npm test` *(échoue : Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894ffe48f6c832cab0e2a6afa2d8996