### PR TITLE
Ajout du workflow CI avec badges de statut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: bot/package-lock.json
+      - name: Installer les dépendances
+        run: npm ci
+        working-directory: bot
+      - name: Lint
+        run: npm run lint --if-present
+        working-directory: bot
+      - name: Tests
+        run: npm test --if-present
+        working-directory: bot

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # AuusaConnect
+[![CI - Push](https://github.com/wshChrist/AuusaConnect/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/wshChrist/AuusaConnect/actions/workflows/ci.yml)
+[![CI - PR](https://github.com/wshChrist/AuusaConnect/actions/workflows/ci.yml/badge.svg?event=pull_request)](https://github.com/wshChrist/AuusaConnect/actions/workflows/ci.yml)
+
 
 Ce dépôt contient un exemple minimal permettant de relier Rocket League (via un plugin Bakkesmod) à un bot Discord pour un système de matchmaking.
 


### PR DESCRIPTION
## Résumé
- Ajout d'un workflow GitHub Actions pour installer les dépendances, exécuter le linter et lancer les tests.
- Ajout de badges de statut de build dans le README.

## Tests
- `npm run lint --if-present`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689508856274832c933b8efd932eea9d