### PR TITLE
Add start script for Node bot

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "start": "node index.js",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- enable npm start for the matchmaking bot

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run start` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'joi')*

------
https://chatgpt.com/codex/tasks/task_e_68952067d794832ca632c9f9a3db6438