### PR TITLE
Ajoute un script de vérification des rangs

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -81,3 +81,13 @@ Le bot reçoit désormais des informations détaillées sur la partie (buteurs, 
 La commande `/team invite` accepte désormais une option `role` pour définir le rôle du joueur invité : `member` (par défaut), `coach` ou `manager`.
 La table `team_invitations` doit donc comporter une colonne `role` de type `text` enregistrant ce choix.
 Une fois l'invitation acceptée avec `/team join`, le bot ajoute automatiquement le rôle Discord de l'équipe au joueur, même si la commande est utilisée en message privé.
+
+### Vérification des rangs
+
+Un script simple `rankVerifier.js` permet de vérifier le rang approximatif d'un joueur à partir d'un jeu de données MMR (`mmr_data.json`).
+
+```bash
+node rankVerifier.js <joueur>
+```
+
+Cette commande affiche le MMR du joueur et le rang correspondant. Modifiez `mmr_data.json` pour y ajouter vos propres valeurs.

--- a/bot/mmr_data.json
+++ b/bot/mmr_data.json
@@ -1,0 +1,7 @@
+{
+  "Alpha": 850,
+  "Bravo": 1100,
+  "Charlie": 1600,
+  "Delta": 2400,
+  "Echo": 3200
+}

--- a/bot/rankVerifier.js
+++ b/bot/rankVerifier.js
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_FILE = path.join(__dirname, 'mmr_data.json');
+
+const thresholds = [
+  { rank: 'Bronze', min: 0, max: 999 },
+  { rank: 'Silver', min: 1000, max: 1499 },
+  { rank: 'Gold', min: 1500, max: 1999 },
+  { rank: 'Platinum', min: 2000, max: 2499 },
+  { rank: 'Diamond', min: 2500, max: 2999 },
+  { rank: 'Champion', min: 3000, max: 3499 },
+  { rank: 'Grand Champion', min: 3500, max: Infinity }
+];
+
+export function computeRank(mmr) {
+  for (const t of thresholds) {
+    if (mmr >= t.min && mmr <= t.max) return t.rank;
+  }
+  return 'Unranked';
+}
+
+export function verifyPlayer(name) {
+  const mmrData = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  const mmr = mmrData[name];
+  if (typeof mmr !== 'number') throw new Error('Joueur inconnu');
+  return { name, mmr, rank: computeRank(mmr) };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const name = process.argv[2];
+  if (!name) {
+    console.error('Usage: node rankVerifier.js <joueur>');
+    process.exit(1);
+  }
+  try {
+    const { name: player, mmr, rank } = verifyPlayer(name);
+    console.log(`${player} possède ${mmr} MMR -> rang ${rank}`);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/bot/tests/rankVerifier.test.js
+++ b/bot/tests/rankVerifier.test.js
@@ -1,0 +1,16 @@
+import { computeRank, verifyPlayer } from '../rankVerifier.js';
+
+test('calcule correctement le rang à partir du MMR', () => {
+  expect(computeRank(900)).toBe('Bronze');
+  expect(computeRank(1100)).toBe('Silver');
+  expect(computeRank(1600)).toBe('Gold');
+});
+
+test('vérifie le joueur existant', () => {
+  const res = verifyPlayer('Charlie');
+  expect(res.rank).toBe('Gold');
+});
+
+test('lance une erreur pour un joueur inconnu', () => {
+  expect(() => verifyPlayer('Inconnu')).toThrow('Joueur inconnu');
+});


### PR DESCRIPTION
## Résumé
- ajoute un jeu de données `mmr_data.json` avec des valeurs MMR d'exemple
- implémente `rankVerifier.js` pour déterminer le rang à partir du MMR
- documente l'utilisation du script dans `bot/README.md`

## Tests
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(échec : module `math-intrinsics/abs` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68952f4838dc832cbe4919dfc6401c43