### PR TITLE
Utiliser GetCurrentMap pour compatibilite

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -776,7 +776,7 @@ void AuusaConnectPlugin::OnGameEnd()
 
     std::string blueName = blueTeam.GetTeamName().ToString();
     std::string orangeName = orangeTeam.GetTeamName().ToString();
-    std::string mapName = sw.GetMapName().ToString();
+    std::string mapName = gameWrapper->GetCurrentMap();
 
     ArrayWrapper<PriWrapper> pris = sw.GetPRIs();
     json players = json::array();


### PR DESCRIPTION
## Résumé
- corrige la compilation en remplaçant `sw.GetMapName()` par `gameWrapper->GetCurrentMap()`

## Tests
- `npm test` *(échoue : sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689534efb4f8832c8fd57574a5d95ec4