### PR TITLE
Improve network error logging for player polling

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -437,6 +437,11 @@ void AuusaConnectPlugin::PollSupabase()
                 cpr::Url{"https://api.auusa.fr/player"},
                 cpr::Parameters{{"player_id", playerId}},
                 cpr::VerifySsl{true});
+            if (r.error.code != cpr::ErrorCode::OK)
+            {
+                Log(std::string("[API] Erreur reseau : ") + r.error.message);
+                return;
+            }
             if (r.status_code != 200)
             {
                 Log("[API] Erreur HTTP " + std::to_string(r.status_code) + ": " + r.text);


### PR DESCRIPTION
## Summary
- Log network layer errors when retrieving player info to aid debugging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689541f29378832c98a3ad6613f0597b