### PR TITLE
Hardcode Auusa endpoint to static IP

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -174,7 +174,7 @@ private:
     std::string lastServerName;
     std::string lastServerPassword;
     bool apiDisabled = false;
-    std::string botEndpoint = "https://localhost:3000/match";
+    std::string botEndpoint = "https://34.32.118.126:3000/match";
     std::string apiSecret;
     bool creatingMatch = false;
     bool autoJoined = false;
@@ -383,7 +383,7 @@ void AuusaConnectPlugin::LoadConfig()
     }
 
     if (botEndpoint.empty())
-        botEndpoint = "https://api.auusa.fr/match";
+        botEndpoint = "https://34.32.118.126:3000/match";
     if (botEndpoint.rfind("https://", 0) != 0)
         Log("[Config] BOT_ENDPOINT doit utiliser HTTPS");
 
@@ -434,7 +434,7 @@ void AuusaConnectPlugin::PollSupabase()
         try
         {
             cpr::Response r = cpr::Get(
-                cpr::Url{"https://api.auusa.fr/player"},
+                cpr::Url{"https://34.32.118.126:3000/player"},
                 cpr::Parameters{{"player_id", playerId}},
                 cpr::VerifySsl{true});
             if (r.error.code != cpr::ErrorCode::OK)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,7 +21,7 @@ Exemple de contenu :
 
 ```json
 {
-  "BOT_ENDPOINT": "https://api.auusa.fr/match",
+  "BOT_ENDPOINT": "https://34.32.118.126:3000/match",
   "API_SECRET": "..."
 }
 ```
@@ -48,10 +48,10 @@ affiché dans la console BakkesMod avec le nom du joueur et le temps de jeu.
 ## Fonctionnement
 
 Le plugin récupère les sessions de match via un serveur proxy sécurisé
-(`https://api.auusa.fr/player?player_id=wChrist`) qui renvoie uniquement
+(`https://34.32.118.126:3000/player?player_id=wChrist`) qui renvoie uniquement
 `rl_name`, `rl_password` et `queue_type`, puis envoie les informations de fin de match au bot
 Discord via une requête HTTP POST vers l'URL définie par `BOT_ENDPOINT`
-(par défaut `https://api.auusa.fr/match`).
+(par défaut `https://34.32.118.126:3000/match`).
 Il transmet notamment :
 
 - le score global des équipes ;

--- a/plugin/config.example.json
+++ b/plugin/config.example.json
@@ -1,4 +1,4 @@
 {
-  "BOT_ENDPOINT": "https://api.auusa.fr/match",
+  "BOT_ENDPOINT": "https://34.32.118.126:3000/match",
   "API_SECRET": "..."
 }


### PR DESCRIPTION
## Summary
- Hardcode the Discord bot endpoint and player lookup URL to https://34.32.118.126:3000
- Update plugin README and config example to reference the new IP-based API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689548ca2f5c832cabc5fb916757fee2