### PR TITLE
Allow HTTP BOT_ENDPOINT

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -386,8 +386,8 @@ void AuusaConnectPlugin::LoadConfig()
 
     if (botEndpoint.empty())
         botEndpoint = std::string(DEFAULT_API_BASE) + "/match";
-    if (botEndpoint.rfind("https://", 0) != 0)
-        Log("[Config] BOT_ENDPOINT doit utiliser HTTPS");
+    if (botEndpoint.rfind("https://", 0) != 0 && botEndpoint.rfind("http://", 0) != 0)
+        Log("[Config] BOT_ENDPOINT doit utiliser HTTP ou HTTPS");
 
     Log("[Config] BOT_ENDPOINT=" + botEndpoint);
     if (apiSecret.empty())


### PR DESCRIPTION
## Summary
- Accept BOT_ENDPOINT URLs starting with http:// as well as https://
- Update configuration log message accordingly

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6895736884e8832cb74db5ab9eff6f32