### PR TITLE
Log HTTP mode and disable SSL when using HTTP

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -899,6 +899,7 @@ void AuusaConnectPlugin::OnGameEnd()
                     if (url.rfind("http://", 0) == 0)
                     {
                         curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_NONE);
+                        Log("Mode HTTP détecté : désactivation de SSL/TLS pour la requête");
                     }
                     curl_easy_setopt(curl, CURLOPT_POST, 1L);
                     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers_list);


### PR DESCRIPTION
## Summary
- log when HTTP endpoint detected and disable SSL

## Testing
- `g++ -c plugin/AuusaConnectPlugin.cpp -o /tmp/AuusaConnectPlugin.o` (fails: bakkesmod headers missing)


------
https://chatgpt.com/codex/tasks/task_e_6895910c5628832ca3a6fd7c35972706