### PR TITLE
Log HTTP mode and disable SSL when using HTTP

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -876,9 +876,9 @@ void AuusaConnectPlugin::OnGameEnd()
     if (debugEnabled)
         Log("[DEBUG] Envoi des stats : " + std::to_string(players.size()) + " joueurs");
 
-    gameWrapper->SetTimeout([this, payload = std::move(payload), url = botEndpoint](GameWrapper* /*gw*/) mutable
+    gameWrapper->SetTimeout([this, payload = std::move(payload)](GameWrapper* /*gw*/) mutable
     {
-        std::thread([this, p = std::move(payload), url]() mutable
+        std::thread([this, p = std::move(payload)]() mutable
         {
             try
             {
@@ -895,10 +895,11 @@ void AuusaConnectPlugin::OnGameEnd()
                 CURL* curl = curl_easy_init();
                 if (curl)
                 {
-                    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-                    if (url.rfind("http://", 0) == 0)
+                    curl_easy_setopt(curl, CURLOPT_URL, botEndpoint.c_str());
+                    if (botEndpoint.rfind("http://", 0) == 0)
                     {
                         curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_NONE);
+                        Log("Mode HTTP détecté : désactivation de SSL/TLS pour la requête");
                     }
                     curl_easy_setopt(curl, CURLOPT_POST, 1L);
                     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers_list);


### PR DESCRIPTION
## Summary
- disable SSL/TLS when the endpoint uses HTTP and log the mode

## Testing
- `g++ -c plugin/AuusaConnectPlugin.cpp -o /tmp/AuusaConnectPlugin.o` (fails: bakkesmod/plugin/bakkesmodplugin.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_6895910c5628832ca3a6fd7c35972706