### PR TITLE
Corrige l'appel de journalisation

### DIFF
--- a/plugin/AuusaConnectPlugin.cpp
+++ b/plugin/AuusaConnectPlugin.cpp
@@ -898,7 +898,7 @@ void AuusaConnectPlugin::OnGameEnd()
                     curl_easy_setopt(curl, CURLOPT_URL, botEndpoint.c_str());
                     if (botEndpoint.rfind("http://", 0) == 0) {
                     curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_NONE);
-                    LOG("Mode HTTP détecté : SSL/TLS désactivé pour cette requête");
+                    Log("Mode HTTP détecté : SSL/TLS désactivé pour cette requête");
                     }
 
                     curl_easy_setopt(curl, CURLOPT_POST, 1L);


### PR DESCRIPTION
## Résumé
- Remplace l'appel à la macro `LOG` par la méthode `Log` dans le plugin afin d'éviter l'erreur de compilation

## Tests
- `bash build_plugin.bat` *(échec attendu : script batch non pris en charge dans l'environnement Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68959c1ac0d0832c98cfe10c9b5ac7f8